### PR TITLE
Fix RS232 reconnect bug

### DIFF
--- a/libsrc/leddevice/LedRs232Device.cpp
+++ b/libsrc/leddevice/LedRs232Device.cpp
@@ -64,7 +64,16 @@ int LedRs232Device::writeBytes(const unsigned size, const uint8_t * data)
 
 	if (!_rs232Port.isOpen())
 	{
-		return -1;
+		// try to reopen
+		int status = open();
+		if(status == -1){
+			// Try again in 3 seconds
+			int seconds = 3000;
+			_blockedForDelay = true;
+			QTimer::singleShot(seconds, this, SLOT(unblockAfterDelay()));
+			std::cout << "Device blocked for " << seconds << " ms" << std::endl;
+		}
+		return status;
 	}
 
 //	for (int i = 0; i < 20; ++i)


### PR DESCRIPTION
Fixes 3rd comment of https://github.com/tvdzwan/hyperion/issues/351
This is not a fix for the whole issue, just partly.

If you unplug the device it will attempt to reconnect to it in 3 seconds. Then you can run hyperion always at startup without having the Arduino/Serial device connected, but it will find it when you plug it in.