### PR TITLE
Add RawHID Device + HID API Device

### DIFF
--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -18,6 +18,8 @@ SET(Leddevice_QT_HEADERS
 		${CURRENT_SOURCE_DIR}/LedDeviceAdalightApa102.h
 		${CURRENT_SOURCE_DIR}/LedDeviceAmbiLed.h
 		${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.h
+		${CURRENT_SOURCE_DIR}/LedHIDDevice.h
+		${CURRENT_SOURCE_DIR}/LedDeviceRawHID.h
 )
 
 SET(Leddevice_HEADERS
@@ -39,10 +41,12 @@ SET(Leddevice_SOURCES
 		${CURRENT_SOURCE_DIR}/LedDeviceFactory.cpp
 
 		${CURRENT_SOURCE_DIR}/LedRs232Device.cpp
+		${CURRENT_SOURCE_DIR}/LedHIDDevice.cpp
 
 		${CURRENT_SOURCE_DIR}/LedDeviceAdalight.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceAdalightApa102.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceAmbiLed.cpp
+		${CURRENT_SOURCE_DIR}/LedDeviceRawHID.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceLightpack.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceMultiLightpack.cpp
 		${CURRENT_SOURCE_DIR}/LedDevicePaintpack.cpp

--- a/libsrc/leddevice/LedDeviceAdalight.h
+++ b/libsrc/leddevice/LedDeviceAdalight.h
@@ -6,7 +6,7 @@
 // Qt includes
 #include <QTimer>
 
-// hyperion incluse
+// hyperion include
 #include "LedRs232Device.h"
 
 ///

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -23,6 +23,7 @@
 
 #include "LedDeviceAdalight.h"
 #include "LedDeviceAmbiLed.h"
+#include "LedDeviceRawHID.h"
 #include "LedDeviceLightpack.h"
 #include "LedDeviceMultiLightpack.h"
 #include "LedDevicePaintpack.h"
@@ -147,6 +148,21 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		device = deviceTinkerforge;
 	}
 #endif
+	else if (type == "rawhid")
+	{
+		const int delay_ms        = deviceConfig["delayAfterConnect"].asInt();
+		auto VendorIdString       = deviceConfig.get("VID", "0x2341").asString();
+		auto ProductIdString      = deviceConfig.get("PID", "0x8036").asString();
+
+		// Convert HEX values to integer
+		auto VendorId = std::stoul(VendorIdString, nullptr, 16);
+		auto ProductId = std::stoul(ProductIdString, nullptr, 16);
+
+		LedDeviceRawHID* deviceHID = new LedDeviceRawHID(VendorId, ProductId, delay_ms);
+		deviceHID->open();
+
+		device = deviceHID;
+	}
 	else if (type == "lightpack")
 	{
 		const std::string output = deviceConfig.get("output", "").asString();

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -181,7 +181,15 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	}
 	else if (type == "paintpack")
 	{
-		LedDevicePaintpack * devicePainLightpack = new LedDevicePaintpack();
+		const int delay_ms        = deviceConfig["delayAfterConnect"].asInt();
+		auto VendorIdString       = deviceConfig.get("VID", "0x0EBF").asString();
+		auto ProductIdString      = deviceConfig.get("PID", "0x0025").asString();
+
+		// Convert HEX values to integer
+		auto VendorId = std::stoul(VendorIdString, nullptr, 16);
+		auto ProductId = std::stoul(ProductIdString, nullptr, 16);
+
+		LedDevicePaintpack * devicePainLightpack = new LedDevicePaintpack(VendorId, ProductId, delay_ms);
 		devicePainLightpack->open();
 
 		device = devicePainLightpack;

--- a/libsrc/leddevice/LedDevicePaintpack.cpp
+++ b/libsrc/leddevice/LedDevicePaintpack.cpp
@@ -2,61 +2,25 @@
 // Hyperion includes
 #include "LedDevicePaintpack.h"
 
-LedDevicePaintpack::LedDevicePaintpack() :
-	LedDevice(),
-	_deviceHandle(nullptr)
+// Use out report HID device
+LedDevicePaintpack::LedDevicePaintpack(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms) :
+	LedHIDDevice(VendorId, ProductId, delayAfterConnect_ms, false),
+	_ledBuffer(0)
 {
 	// empty
 }
 
-int LedDevicePaintpack::open()
+
+int LedDevicePaintpack::write(const std::vector<ColorRgb> & ledValues)
 {
-	// initialize the usb context
-	int error = hid_init();
-	if (error != 0)
+	if (_ledBuffer.size() < 2 + ledValues.size()*3)
 	{
-		std::cerr << "Error while initializing the hidapi context" << std::endl;
-		return -1;
-	}
-	std::cout << "Hidapi initialized" << std::endl;
-
-	// Initialise the paintpack device
-	const unsigned short Paintpack_VendorId  = 0x0ebf;
-	const unsigned short Paintpack_ProductId = 0x0025;
-	_deviceHandle = hid_open(Paintpack_VendorId, Paintpack_ProductId, nullptr);
-	if (_deviceHandle == nullptr)
-	{
-		// Failed to open the device
-		std::cerr << "Failed to open HID Paintpakc device " << std::endl;
-		return -1;
+		_ledBuffer.resize(2 + ledValues.size()*3, uint8_t(0));
+		_ledBuffer[0] = 3;
+		_ledBuffer[1] = 0;
 	}
 
-	return 0;
-}
-
-LedDevicePaintpack::~LedDevicePaintpack()
-{
-	if (_deviceHandle != nullptr)
-	{
-		hid_close(_deviceHandle);
-		_deviceHandle = nullptr;
-	}
-
-	hid_exit();
-}
-
-int LedDevicePaintpack::write(const std::vector<ColorRgb>& ledValues)
-{
-	if (_ledBuffer.size() < 3 + ledValues.size()*3)
-	{
-		_ledBuffer.resize(3 + ledValues.size()*3, uint8_t(0));
-
-		_ledBuffer[0] = 0;
-		_ledBuffer[1] = 3;
-		_ledBuffer[2] = 0;
-	}
-
-	auto bufIt = _ledBuffer.begin()+3;
+	auto bufIt = _ledBuffer.begin()+2;
 	for (const ColorRgb & ledValue : ledValues)
 	{
 		*bufIt = ledValue.red;
@@ -67,11 +31,12 @@ int LedDevicePaintpack::write(const std::vector<ColorRgb>& ledValues)
 		++bufIt;
 	}
 
-	return hid_write(_deviceHandle, _ledBuffer.data(), _ledBuffer.size());
+	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
 }
+
 
 int LedDevicePaintpack::switchOff()
 {
-	std::fill(_ledBuffer.begin()+3, _ledBuffer.end(), uint8_t(0));
-	return hid_write(_deviceHandle, _ledBuffer.data(), _ledBuffer.size());
+	std::fill(_ledBuffer.begin() + 2, _ledBuffer.end(), uint8_t(0));
+	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
 }

--- a/libsrc/leddevice/LedDevicePaintpack.h
+++ b/libsrc/leddevice/LedDevicePaintpack.h
@@ -3,34 +3,19 @@
 // STL includes
 #include <vector>
 
-// libusb include
-#include <hidapi/hidapi.h>
-
 // Hyperion includes
-#include <leddevice/LedDevice.h>
+#include "LedHIDDevice.h"
 
 ///
 /// LedDevice implementation for a paintpack device ()
 ///
-class LedDevicePaintpack : public LedDevice
+class LedDevicePaintpack : public LedHIDDevice
 {
 public:
 	/**
 	 * Constructs the paintpack device
 	 */
-	LedDevicePaintpack();
-
-	/**
-	 * Destructs the paintpack device, closes USB connection if open
-	 */
-	virtual ~LedDevicePaintpack();
-
-	/**
-	 * Opens the Paintpack device
-	 *
-	 * @return Zero on succes else negative
-	 */
-	int open();
+	LedDevicePaintpack(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms);
 
 	///
 	/// Writes the RGB-Color values to the leds.
@@ -49,11 +34,6 @@ public:
 	virtual int switchOff();
 
 private:
-	/// libusb device handle
-	hid_device * _deviceHandle;
-
 	/// buffer for led data
 	std::vector<uint8_t> _ledBuffer;
-
-
 };

--- a/libsrc/leddevice/LedDeviceRawHID.cpp
+++ b/libsrc/leddevice/LedDeviceRawHID.cpp
@@ -1,0 +1,57 @@
+
+// STL includes
+#include <cstring>
+#include <cstdio>
+#include <iostream>
+
+// Linux includes
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+// hyperion local includes
+#include "LedDeviceRawHID.h"
+
+// Use feature report HID device
+LedDeviceRawHID::LedDeviceRawHID(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms) :
+	LedHIDDevice(VendorId, ProductId, delayAfterConnect_ms, true),
+	_ledBuffer(0),
+	_timer()
+{
+	// setup the timer
+	_timer.setSingleShot(false);
+	_timer.setInterval(5000);
+	connect(&_timer, SIGNAL(timeout()), this, SLOT(rewriteLeds()));
+
+	// start the timer
+	_timer.start();
+}
+
+int LedDeviceRawHID::write(const std::vector<ColorRgb> & ledValues)
+{
+	// Resize buffer if required
+	if (_ledBuffer.size() < ledValues.size() * 3) {
+		_ledBuffer.resize(3 * ledValues.size());
+	}
+
+	// restart the timer
+	_timer.start();
+
+	// write data
+	memcpy(_ledBuffer.data(), ledValues.data(), ledValues.size() * 3);
+	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}
+
+int LedDeviceRawHID::switchOff()
+{
+	// restart the timer
+	_timer.start();
+
+	// write data
+	std::fill(_ledBuffer.begin(), _ledBuffer.end(), uint8_t(0));
+	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}
+
+void LedDeviceRawHID::rewriteLeds()
+{
+	writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}

--- a/libsrc/leddevice/LedDeviceRawHID.h
+++ b/libsrc/leddevice/LedDeviceRawHID.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// STL includes
+#include <string>
+
+// Qt includes
+#include <QTimer>
+
+// hyperion include
+#include "LedHIDDevice.h"
+
+///
+/// Implementation of the LedDevice interface for writing to an RawHID led device.
+///
+class LedDeviceRawHID : public LedHIDDevice
+{
+	Q_OBJECT
+
+public:
+	///
+	/// Constructs the LedDevice for attached RawHID device
+	///
+	LedDeviceRawHID(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms);
+
+	///
+	/// Writes the led color values to the led-device
+	///
+	/// @param ledValues The color-value per led
+	/// @return Zero on succes else negative
+	///
+	virtual int write(const std::vector<ColorRgb> & ledValues);
+
+	/// Switch the leds off
+	virtual int switchOff();
+
+private slots:
+	/// Write the last data to the leds again
+	void rewriteLeds();
+
+private:
+	/// The buffer containing the packed RGB values
+	std::vector<uint8_t> _ledBuffer;
+
+	/// Timer object which makes sure that led data is written at a minimum rate
+	/// The RawHID device will switch off when it does not receive data at least
+	/// every 15 seconds
+	QTimer _timer;
+};

--- a/libsrc/leddevice/LedHIDDevice.cpp
+++ b/libsrc/leddevice/LedHIDDevice.cpp
@@ -49,7 +49,7 @@ int LedHIDDevice::open()
 	if (_deviceHandle == nullptr)
 	{
 		// Failed to open the device
-		std::cerr << "Failed to open HID device. Maybe your PID/VID setting is wrong?" << std::endl;
+		std::cerr << "Failed to open HID device. Maybe your PID/VID setting is wrong? Make sure to add a udev rule/use sudo." << std::endl;
 		
 		// http://www.signal11.us/oss/hidapi/
 		/*

--- a/libsrc/leddevice/LedHIDDevice.cpp
+++ b/libsrc/leddevice/LedHIDDevice.cpp
@@ -1,0 +1,152 @@
+
+// STL includes
+#include <cstring>
+#include <iostream>
+
+// Qt includes
+#include <QTimer>
+
+// Local Hyperion includes
+#include "LedHIDDevice.h"
+
+LedHIDDevice::LedHIDDevice(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms, const bool useFeature) :
+	_VendorId(VendorId),
+	_ProductId(ProductId),
+	_useFeature(useFeature),
+	_deviceHandle(nullptr),
+	_delayAfterConnect_ms(delayAfterConnect_ms),
+	_blockedForDelay(false)
+{
+	// empty
+}
+
+LedHIDDevice::~LedHIDDevice()
+{
+	if (_deviceHandle != nullptr)
+	{
+		hid_close(_deviceHandle);
+		_deviceHandle = nullptr;
+	}
+
+	hid_exit();
+}
+
+int LedHIDDevice::open()
+{
+	// Initialize the usb context
+	int error = hid_init();
+	if (error != 0)
+	{
+		std::cerr << "Error while initializing the hidapi context" << std::endl;
+		return -1;
+	}
+	std::cout << "Hidapi initialized" << std::endl;
+
+	// Open the device
+	printf("Opening device: VID %04hx PID %04hx\n", _VendorId, _ProductId);
+	_deviceHandle = hid_open(_VendorId, _ProductId, nullptr);
+		
+	if (_deviceHandle == nullptr)
+	{
+		// Failed to open the device
+		std::cerr << "Failed to open HID device. Maybe your PID/VID setting is wrong?" << std::endl;
+		
+		// http://www.signal11.us/oss/hidapi/
+		/*
+		std::cout << "Showing a list of all available HID devices:" << std::endl;
+		auto devs = hid_enumerate(0x00, 0x00);
+		auto cur_dev = devs;	
+		while (cur_dev) {
+			printf("Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %ls",
+				cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, cur_dev->serial_number);
+			printf("\n");
+			printf("  Manufacturer: %ls\n", cur_dev->manufacturer_string);
+			printf("  Product:      %ls\n", cur_dev->product_string);
+			printf("\n");
+			cur_dev = cur_dev->next;
+		}
+		hid_free_enumeration(devs);
+		*/
+		
+		return -1;
+	}
+	else{
+		std::cout << "Opened HID device successful" << std::endl;
+	}
+	
+	// Wait after device got opened if enabled
+	if (_delayAfterConnect_ms > 0)
+	{
+		_blockedForDelay = true;
+		QTimer::singleShot(_delayAfterConnect_ms, this, SLOT(unblockAfterDelay()));
+		std::cout << "Device blocked for " << _delayAfterConnect_ms << " ms" << std::endl;
+	}
+
+	return 0;
+}
+
+
+int LedHIDDevice::writeBytes(const unsigned size, const uint8_t * data)
+{
+	if (_blockedForDelay) {
+		return 0;
+	}
+
+	if (_deviceHandle == nullptr)
+	{
+		// try to reopen
+		auto status = open();
+		if(status < 0){
+			// Try again in 3 seconds
+			int seconds = 3000;
+			_blockedForDelay = true;
+			QTimer::singleShot(seconds, this, SLOT(unblockAfterDelay()));
+			std::cout << "Device blocked for " << seconds << " ms" << std::endl;
+		}
+		// Return here, to not write led data if the device should be blocked after connect
+		return status;
+	}
+
+	// Prepend report ID to the buffer
+	uint8_t ledData[size + 1];
+	ledData[0] = 0; // Report ID
+	memcpy(ledData + 1, data, size_t(size));
+
+	// Send data via feature or out report
+	int ret;
+	if(_useFeature){
+		ret = hid_send_feature_report(_deviceHandle, ledData, size + 1);
+	}
+	else{
+		ret = hid_write(_deviceHandle, ledData, size + 1);
+	}
+	
+	// Handle first error
+	if(ret < 0){
+		std::cerr << "Failed to write to HID device." << std::endl;
+
+		// Try again
+		if(_useFeature){
+			ret = hid_send_feature_report(_deviceHandle, ledData, size + 1);
+		}
+		else{
+			ret = hid_write(_deviceHandle, ledData, size + 1);
+		}
+
+		// Writing failed again, device might have disconnected
+		if(ret < 0){
+			std::cerr << "Failed to write to HID device." << std::endl;
+		
+			hid_close(_deviceHandle);
+			_deviceHandle = nullptr;
+		}
+	}
+	
+	return ret;
+}
+
+void LedHIDDevice::unblockAfterDelay()
+{
+	std::cout << "Device unblocked" << std::endl;
+	_blockedForDelay = false;
+}

--- a/libsrc/leddevice/LedHIDDevice.h
+++ b/libsrc/leddevice/LedHIDDevice.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QObject>
+
+// libusb include
+#include <hidapi/hidapi.h>
+
+// Leddevice includes
+#include <leddevice/LedDevice.h>
+
+///
+/// The LedHIDDevice implements an abstract base-class for LedDevices using an HID-device.
+///
+class LedHIDDevice : public QObject, public LedDevice
+{
+	Q_OBJECT
+
+public:
+	///
+	/// Constructs the LedDevice attached to an HID-device
+	///
+	/// @param[in] VendorId The USB VID of the output device
+	/// @param[in] ProductId The USB PID of the output device
+	///
+	LedHIDDevice(const unsigned short VendorId, const unsigned short ProductId, int delayAfterConnect_ms = 0, const bool useFeature = false);
+
+	///
+	/// Destructor of the LedDevice; closes the output device if it is open
+	///
+	virtual ~LedHIDDevice();
+
+	///
+	/// Opens and configures the output device
+	///
+	/// @return Zero on succes else negative
+	///
+	int open();
+protected:
+	/**
+	 * Writes the given bytes to the HID-device and
+	 *
+	 * @param[in[ size The length of the data
+	 * @param[in] data The data
+	 *
+	 * @return Zero on succes else negative
+	 */
+	int writeBytes(const unsigned size, const uint8_t *data);
+
+private slots:
+	/// Unblock the device after a connection delay
+	void unblockAfterDelay();
+
+private:
+	// HID VID and PID
+	const unsigned short _VendorId;
+	const unsigned short _ProductId;
+	const bool _useFeature;
+
+	/// libusb device handle
+	hid_device * _deviceHandle;
+
+	/// Sleep after the connect before continuing
+	const int _delayAfterConnect_ms;
+
+	bool _blockedForDelay;
+};


### PR DESCRIPTION
This PR adds a new generic HID device which relies on the already used HIDAPI. This way we do not need to duplicate the code for the HID API handling. It also fixes reconnection issues. The new HID Device will reconnect after 3 seconds if connection was lost. On top of that you can now (optionally) change the USB PID and VID via the json config file.

On top of that a new RawHID device was added which works with the current dev version of the HID Project. This way you can simply use an Arduino (as keyboard!) to receive data, not even a real RawHID device is required (but would also work). Both feature and report out is supported.
More information about this can be found here:
https://github.com/arduino/Arduino/pull/4105

If you like to, you can adapt this api to other led devices. I did this for the paintpack. I dont own a paintpack device myself, but my arduino can pretend to be one and it works (as it did before the patch, just with a changed VID and PID). So nothing should break here. I made sure it uses the out report again, not the feature report.
Test sketch with paintpack (works with/without this PR) https://github.com/NicoHood/HID/blob/dev/examples/RawHID/RawHIDPaintpack/RawHIDPaintpack.ino

Sample config (only name, VID and PID are important). If no PID/VID setting was added it will use the default hardcoded values. To use the Arduino as ambilight receiver you can use name "rawhid" instead.
```json
	"device" :
	{
		"name"       : "MyPi",
		"type"       : "paintpack",
		"output"     : "/dev/ttyACM0",
		"VID"        : "0x2341",
		"PID"        : "0x8036",
		"rate"       : 115200,
		"colorOrder" : "rgb"
	},
```