### PR TITLE
Typos in Compile Instructions + clone only latest git

### DIFF
--- a/CompileHowto.txt
+++ b/CompileHowto.txt
@@ -40,3 +40,6 @@ make
 # The binaries are build in "$HYPERION_DIR/build/bin". You could copy those to /usr/bin
 sudo cp ./bin/hyperion-remote /usr/bin/
 sudo cp ./bin/hyperiond /usr/bin/
+
+# Copy the effect folder (if you did not use the normal installation methode before)
+sudo mkdir -p /opt/hyperion/effects && sudo cp -R ../effects/ /opt/hyperion/

--- a/CompileHowto.txt
+++ b/CompileHowto.txt
@@ -2,14 +2,15 @@
 sudo apt-get update
 sudo apt-get install git cmake build-essential libQt4-dev libusb-1.0-0-dev python-dev
 
-# RPI ONLY: when you build on the rapberry pi and inlcude the dispmanx grabber (which is the default) 
+# RPI ONLY: when you build on the rapberry pi and include the dispmanx grabber (which is the default) 
 # you also need the firmware including headers installed. This downloads the firmware from the raspberrypi github
 # and copies the required files to the correct place. The firmware directory can be deleted afterwards if desired.
 export FIRMWARE_DIR="raspberrypi-firmware"
-git clone https://github.com/raspberrypi/firmware.git "$FIRMWARE_DIR"
-sudo cp -R "$FIRMWARE_DIR/hardfp/opt/*" /opt
+git clone --depth 1 https://github.com/raspberrypi/firmware.git "$FIRMWARE_DIR"
+sudo cp -R "$FIRMWARE_DIR/hardfp/opt/" /opt
 
 # create hyperion directory and checkout the code from github
+# You might want to add "--depth 1" if you only want to recompile the current source or dont want to use git any further
 export HYPERION_DIR="hyperion"
 git clone --recursive https://github.com/tvdzwan/hyperion.git "$HYPERION_DIR"
 
@@ -22,7 +23,7 @@ git submodule update
 mkdir "$HYPERION_DIR/build"
 cd "$HYPERION_DIR/build"
 
-# run cmake to generate make files on the rsapberry pi
+# run cmake to generate make files on the raspberry pi
 cmake ..
 # or if you are not compiling on the raspberry pi and need to disable the Dispmanx grabber and support for spi devices
 cmake -DENABLE_DISPMANX=OFF -DENABLE_SPIDEV=OFF -DENABLE_X11=ON ..


### PR DESCRIPTION
Downloading the raspi firmware took me forever. Since its only copied once and not really important to have the whole history, I added `--depth 1` to it. Otherwise it trashes the SD card.

Also I added a note for the normal hyperion git, since hyperion also has all binaries in the history which is pretty time and space consuming. I didnt add it by default, since if people want to push commits I think this would not work properly. See this: https://github.com/tvdzwan/hyperion/issues/392