### PR TITLE
add FadeCandy/OPC device support

### DIFF
--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -20,6 +20,8 @@ SET(Leddevice_QT_HEADERS
 		${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.h
 		${CURRENT_SOURCE_DIR}/LedHIDDevice.h
 		${CURRENT_SOURCE_DIR}/LedDeviceRawHID.h
+		${CURRENT_SOURCE_DIR}/LedDeviceTest.h
+		${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.h
 )
 
 SET(Leddevice_HEADERS
@@ -32,6 +34,7 @@ SET(Leddevice_HEADERS
 		${CURRENT_SOURCE_DIR}/LedDevicePiBlaster.h
 		${CURRENT_SOURCE_DIR}/LedDeviceSedu.h
 		${CURRENT_SOURCE_DIR}/LedDeviceTest.h
+		${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.h
 		${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.h
 		${CURRENT_SOURCE_DIR}/LedDeviceTpm2.h
 		${CURRENT_SOURCE_DIR}/LedDeviceAtmo.h
@@ -53,6 +56,7 @@ SET(Leddevice_SOURCES
 		${CURRENT_SOURCE_DIR}/LedDevicePiBlaster.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceSedu.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceTest.cpp
+		${CURRENT_SOURCE_DIR}/LedDeviceFadeCandy.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceHyperionUsbasp.cpp
 		${CURRENT_SOURCE_DIR}/LedDevicePhilipsHue.cpp
 		${CURRENT_SOURCE_DIR}/LedDeviceTpm2.cpp
@@ -114,7 +118,7 @@ add_library(leddevice
 
 target_link_libraries(leddevice
 	hyperion-utils
-	serialport
+        serialport
 	${LIBUSB_1_LIBRARIES} #apt-get install libusb-1.0-0-dev
 	${CMAKE_THREAD_LIBS_INIT}
 	${QT_LIBRARIES}

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -247,7 +247,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	else if (type == "fadecandy")
 	{
 		const std::string host 	= deviceConfig.get("output", "127.0.0.1").asString();
-		const uint16_t port 		= deviceConfig.get("port", 8080).asInt();
+		const uint16_t port 		= deviceConfig.get("port", 7890).asInt();
 		device = new LedDeviceFadeCandy(host,port);
 	}
 	else if (type == "tpm2")

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -30,6 +30,7 @@
 #include "LedDevicePiBlaster.h"
 #include "LedDeviceSedu.h"
 #include "LedDeviceTest.h"
+#include "LedDeviceFadeCandy.h"
 #include "LedDeviceHyperionUsbasp.h"
 #include "LedDevicePhilipsHue.h"
 #include "LedDeviceTpm2.h"
@@ -242,6 +243,12 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	{
 		const std::string output = deviceConfig["output"].asString();
 		device = new LedDeviceTest(output);
+	}
+	else if (type == "fadecandy")
+	{
+		const std::string host 	= deviceConfig.get("output", "127.0.0.1").asString();
+		const uint16_t port 		= deviceConfig.get("port", 8080).asInt();
+		device = new LedDeviceFadeCandy(host,port);
 	}
 	else if (type == "tpm2")
 	{

--- a/libsrc/leddevice/LedDeviceFadeCandy.cpp
+++ b/libsrc/leddevice/LedDeviceFadeCandy.cpp
@@ -21,8 +21,6 @@ LedDeviceFadeCandy::LedDeviceFadeCandy(const std::string& host, const uint16_t p
     _opc_data[1] = OPC_SET_PIXELS;
     _opc_data[2] = 0;
     _opc_data[3] = 0;
-
-    qDebug("connect to %s %i",_host.c_str(),_port);
 }
 
 LedDeviceFadeCandy::~LedDeviceFadeCandy()
@@ -38,7 +36,7 @@ bool LedDeviceFadeCandy::isConnected()
 bool LedDeviceFadeCandy::tryConnect()
 {
     if (  _client.state() == QAbstractSocket::UnconnectedState ) {
-        qDebug("connecting");
+        qDebug("connecting to %s %i",_host.c_str(),_port);
         QHostAddress addr(_host.c_str());
         _client.connectToHost(addr, _port);
         if (_client.waitForConnected(1000))

--- a/libsrc/leddevice/LedDeviceFadeCandy.cpp
+++ b/libsrc/leddevice/LedDeviceFadeCandy.cpp
@@ -1,0 +1,89 @@
+
+// Local-Hyperion includes
+#include "LedDeviceFadeCandy.h"
+#include <QHostAddress>
+#include <QString>
+#include <sstream>
+
+static const unsigned MAX_NUM_LEDS = 512;
+
+/* OPC broadcast channel */
+static const unsigned OPC_BROADCAST = 0;
+
+/* OPC command codes */
+static const unsigned OPC_SET_PIXELS = 0;
+
+LedDeviceFadeCandy::LedDeviceFadeCandy(const std::string& host, const uint16_t port)
+    : _host(host), _port(port)
+{
+    _opc_data.resize(4);
+    _opc_data[0] = OPC_BROADCAST;
+    _opc_data[1] = OPC_SET_PIXELS;
+    _opc_data[2] = 0;
+    _opc_data[3] = 0;
+
+    qDebug("connect to %s %i",_host.c_str(),_port);
+}
+
+LedDeviceFadeCandy::~LedDeviceFadeCandy()
+{
+    _client.close();
+}
+
+bool LedDeviceFadeCandy::isConnected()
+{
+    return _client.state() == QAbstractSocket::ConnectedState;
+}
+
+bool LedDeviceFadeCandy::tryConnect()
+{
+    if (  _client.state() == QAbstractSocket::UnconnectedState ) {
+        qDebug("connecting");
+        QHostAddress addr(_host.c_str());
+        _client.connectToHost(addr, _port);
+        if (_client.waitForConnected(1000))
+            qDebug("connected");
+    }
+
+    return isConnected();
+}
+
+
+int LedDeviceFadeCandy::write(const std::vector<ColorRgb> & ledValues)
+{
+    ssize_t nrLedValues = ledValues.size();
+    ssize_t led_data_size = nrLedValues*3;    // 3 color bytes
+    ssize_t opc_data_size = led_data_size +4; // + 4 byte header
+
+    if (nrLedValues > MAX_NUM_LEDS)
+    {
+        std::cerr << "Invalid attempt to write led values. Not more than " << MAX_NUM_LEDS << " leds are allowed." << std::endl;
+        return -1;
+    }
+
+    if ( opc_data_size != _opc_data.size())
+        _opc_data.resize(opc_data_size);
+
+    _opc_data[2] = led_data_size >> 8;
+    _opc_data[3] = led_data_size & 0xff;
+
+    if ( isConnected() || tryConnect() ) {
+        u_int16_t idx = 4;
+        for (const ColorRgb& color : ledValues)
+        {
+            _opc_data[idx] = unsigned(color.red);
+            _opc_data[idx+1] = unsigned(color.green);
+            _opc_data[idx+2] = unsigned(color.blue);
+            idx += 3;
+        }
+        _client.write(_opc_data, opc_data_size);
+    }
+
+    return 0;
+}
+
+
+int LedDeviceFadeCandy::switchOff()
+{
+	return 0;
+}

--- a/libsrc/leddevice/LedDeviceFadeCandy.cpp
+++ b/libsrc/leddevice/LedDeviceFadeCandy.cpp
@@ -1,87 +1,93 @@
-
-// Local-Hyperion includes
 #include "LedDeviceFadeCandy.h"
-#include <QHostAddress>
-#include <QString>
-#include <sstream>
 
-static const unsigned MAX_NUM_LEDS = 512;
+static const unsigned MAX_NUM_LEDS    = 512;
+static const unsigned OPC_BROADCAST   = 0;    // OPC broadcast channel
+static const unsigned OPC_SET_PIXELS  = 0;    // OPC command codes
+static const unsigned OPC_HEADER_SIZE = 4;    // OPC header size
 
-/* OPC broadcast channel */
-static const unsigned OPC_BROADCAST = 0;
 
-/* OPC command codes */
-static const unsigned OPC_SET_PIXELS = 0;
-
-LedDeviceFadeCandy::LedDeviceFadeCandy(const std::string& host, const uint16_t port)
-    : _host(host), _port(port)
+LedDeviceFadeCandy::LedDeviceFadeCandy(const std::string& host, const uint16_t port) :
+	_host(host), _port(port)
 {
-    _opc_data.resize(4);
-    _opc_data[0] = OPC_BROADCAST;
-    _opc_data[1] = OPC_SET_PIXELS;
-    _opc_data[2] = 0;
-    _opc_data[3] = 0;
+	_opc_data.resize( OPC_HEADER_SIZE );
+	_opc_data[0] = OPC_BROADCAST;
+	_opc_data[1] = OPC_SET_PIXELS;
+	_opc_data[2] = 0;
+	_opc_data[3] = 0;
 }
+
 
 LedDeviceFadeCandy::~LedDeviceFadeCandy()
 {
-    _client.close();
+	_client.close();
 }
+
 
 bool LedDeviceFadeCandy::isConnected()
 {
-    return _client.state() == QAbstractSocket::ConnectedState;
+	return _client.state() == QAbstractSocket::ConnectedState;
 }
+
 
 bool LedDeviceFadeCandy::tryConnect()
 {
-    if (  _client.state() == QAbstractSocket::UnconnectedState ) {
-        qDebug("connecting to %s %i",_host.c_str(),_port);
-        QHostAddress addr(_host.c_str());
-        _client.connectToHost(addr, _port);
-        if (_client.waitForConnected(1000))
-            qDebug("connected");
-    }
+	if (  _client.state() == QAbstractSocket::UnconnectedState ) {
+		qDebug("connecting to %s %i",_host.c_str(),_port);
 
-    return isConnected();
+		_client.connectToHost( _host.c_str(), _port);
+		if ( _client.waitForConnected(1000) )
+			qDebug("connected");
+	}
+
+	return isConnected();
 }
 
 
-int LedDeviceFadeCandy::write(const std::vector<ColorRgb> & ledValues)
+int LedDeviceFadeCandy::write( const std::vector<ColorRgb> & ledValues )
 {
-    ssize_t nrLedValues = ledValues.size();
-    ssize_t led_data_size = nrLedValues*3;    // 3 color bytes
-    ssize_t opc_data_size = led_data_size +4; // + 4 byte header
+	ssize_t nrLedValues = ledValues.size();
+	ssize_t led_data_size = nrLedValues * 3;    // 3 color bytes
+	ssize_t opc_data_size = led_data_size + OPC_HEADER_SIZE;
 
-    if (nrLedValues > MAX_NUM_LEDS)
-    {
-        std::cerr << "Invalid attempt to write led values. Not more than " << MAX_NUM_LEDS << " leds are allowed." << std::endl;
-        return -1;
-    }
+	if (nrLedValues > MAX_NUM_LEDS)
+	{
+		std::cerr << "Invalid attempt to write led values. Not more than " << MAX_NUM_LEDS << " leds are allowed." << std::endl;
+		return -1;
+	}
 
-    if ( opc_data_size != _opc_data.size())
-        _opc_data.resize(opc_data_size);
+	if ( opc_data_size != _opc_data.size() )
+		_opc_data.resize( opc_data_size );
 
-    _opc_data[2] = led_data_size >> 8;
-    _opc_data[3] = led_data_size & 0xff;
+	_opc_data[2] = led_data_size >> 8;
+	_opc_data[3] = led_data_size & 0xff;
 
-    if ( isConnected() || tryConnect() ) {
-        u_int16_t idx = 4;
-        for (const ColorRgb& color : ledValues)
-        {
-            _opc_data[idx] = unsigned(color.red);
-            _opc_data[idx+1] = unsigned(color.green);
-            _opc_data[idx+2] = unsigned(color.blue);
-            idx += 3;
-        }
-        _client.write(_opc_data, opc_data_size);
-    }
+	uint idx = OPC_HEADER_SIZE;
+	for (const ColorRgb& color : ledValues)
+	{
+		_opc_data[idx  ] = unsigned( color.red   );
+		_opc_data[idx+1] = unsigned( color.green );
+		_opc_data[idx+2] = unsigned( color.blue  );
+		idx += 3;
+	}
 
-    return 0;
+	return ( transferData()<0 ? -1 : 0 );
+}
+
+
+int LedDeviceFadeCandy::transferData()
+{
+	if ( isConnected() || tryConnect() )
+		return _client.write( _opc_data, _opc_data.size() );
+
+	return -2;
 }
 
 
 int LedDeviceFadeCandy::switchOff()
 {
-	return 0;
+	for ( int idx=OPC_HEADER_SIZE; idx < _opc_data.size(); idx++ )
+		_opc_data[idx] = 0;
+
+	return ( transferData()<0 ? -1 : 0 );
 }
+

--- a/libsrc/leddevice/LedDeviceFadeCandy.h
+++ b/libsrc/leddevice/LedDeviceFadeCandy.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// STL includes0
+#include <fstream>
+#include <QObject>
+#include <QtNetwork>
+#include <QObject>
+#include <QString>
+#include <QTcpSocket>
+
+// Leddevice includes
+#include <leddevice/LedDevice.h>
+
+
+///
+/// Implementation of the LedDevice that write the led-colors to an
+/// ASCII-textfile('/home/pi/LedDevice.out')
+///
+class LedDeviceFadeCandy : public QObject,public LedDevice
+{
+        Q_OBJECT
+public:
+	///
+	/// Constructs the test-device, which opens an output stream to the file
+	///
+	LedDeviceFadeCandy(const std::string& host, const uint16_t port);
+
+	///
+	/// Destructor of this test-device
+	///
+	virtual ~LedDeviceFadeCandy();
+
+	///
+	/// Writes the given led-color values to the output stream
+	///
+	/// @param ledValues The color-value per led
+	///
+	/// @return Zero on success else negative
+	///
+	virtual int write(const std::vector<ColorRgb> & ledValues);
+
+	/// Switch the leds off
+	virtual int switchOff();
+
+    bool tryConnect();
+    bool isConnected();
+
+//public slots:
+
+private:
+    QTcpSocket _client;
+    const std::string _host;
+    const uint16_t _port;
+    QByteArray _opc_data;
+};

--- a/libsrc/leddevice/LedDeviceFadeCandy.h
+++ b/libsrc/leddevice/LedDeviceFadeCandy.h
@@ -1,55 +1,70 @@
 #pragma once
 
-// STL includes0
+// STL/Qt includes
 #include <fstream>
 #include <QObject>
-#include <QtNetwork>
-#include <QObject>
-#include <QString>
 #include <QTcpSocket>
 
 // Leddevice includes
 #include <leddevice/LedDevice.h>
 
-
 ///
-/// Implementation of the LedDevice that write the led-colors to an
-/// ASCII-textfile('/home/pi/LedDevice.out')
+/// Implementation of the LedDevice interface for sending to
+/// fadecandy/opc-server via network by using the 'open pixel control' protocol.
 ///
-class LedDeviceFadeCandy : public QObject,public LedDevice
+class LedDeviceFadeCandy : public QObject, public LedDevice
 {
-        Q_OBJECT
+	Q_OBJECT
+
 public:
 	///
-	/// Constructs the test-device, which opens an output stream to the file
+	/// Constructs the LedDevice for fadecandy/opc server
+	///
+	/// @param host The ip address/host name of fadecandy/opc server
+	/// @param port The port to use (fadecandy default is 7890)
 	///
 	LedDeviceFadeCandy(const std::string& host, const uint16_t port);
 
 	///
-	/// Destructor of this test-device
+	/// Destructor of the LedDevice; closes the tcp client
 	///
 	virtual ~LedDeviceFadeCandy();
 
 	///
-	/// Writes the given led-color values to the output stream
+	/// Writes the led color values to the led-device
 	///
 	/// @param ledValues The color-value per led
-	///
-	/// @return Zero on success else negative
+	/// @return Zero on succes else negative
 	///
 	virtual int write(const std::vector<ColorRgb> & ledValues);
 
 	/// Switch the leds off
 	virtual int switchOff();
 
-    bool tryConnect();
-    bool isConnected();
-
-//public slots:
 
 private:
-    QTcpSocket _client;
-    const std::string _host;
-    const uint16_t _port;
-    QByteArray _opc_data;
+	QTcpSocket        _client;
+	const std::string _host;
+	const uint16_t    _port;
+	QByteArray        _opc_data;
+
+	/// try to establish connection to opc server, if not connected yet
+	///
+	/// @return true if connection is established
+	///
+	bool tryConnect();
+
+	/// return the conenction state
+	///
+	/// @return True if connection established
+	///
+	bool isConnected();
+
+
+	/// transfer current opc_data buffer to opc server
+	///
+	/// @return amount of transfered bytes. -1 error while transfering, -2 error while connecting
+	///
+	int transferData();
+	
 };


### PR DESCRIPTION
I've got the Adafruit FadeCandy Controller (https://www.adafruit.com/products/1689) working. This device uses the OPC Standard (http://openpixelcontrol.org/). You can use the driver also for other OPC devices.

This implemention uses the "fcserver" via network. Set your "output" in hyperion.config.json to the fcserver address (e.g. 127.0.0.1 ). If you want to set an individual port, set "port" variable in config too.

(tested on rpi 1 and linux)
