### PR TITLE
Blackborder Improved

### DIFF
--- a/include/blackborder/BlackBorderDetector.h
+++ b/include/blackborder/BlackBorderDetector.h
@@ -61,10 +61,50 @@ namespace hyperion
 		template <typename Pixel_T>
 		BlackBorder process(const Image<Pixel_T> & image)
 		{
+
+			// only test the topleft third of the image
+			int width = image.width() / 3;
+			int height = image.height() / 3;
+			int xCenter = image.width() / 2;
+			int yCenter = image.height() / 2;
+//			int maxSize = std::max(width, height);
+
+
+
+			int firstNonBlackXPixelIndex = -1;
+			int firstNonBlackYPixelIndex = -1;
+
+			// find first X pixel of the image
+			for (int x = 0; x < width; ++x)
+			{
+				const Pixel_T & color = image(x, yCenter);
+				if (!isBlack(color))
+				{
+					firstNonBlackXPixelIndex = x;
+					break;
+				}
+			}
+
+			// find first Y pixel of the image
+			for (int y = 0; y < height; ++y)
+			{
+				const Pixel_T & color = image(xCenter, y);
+				if (!isBlack(color))
+				{
+					firstNonBlackYPixelIndex = y;
+					break;
+				}
+			}
+
+
+
+/*
 			// only test the topleft third of the image
 			int width = image.width() /3;
 			int height = image.height() / 3;
 			int maxSize = std::max(width, height);
+
+
 
 			int firstNonBlackXPixelIndex = -1;
 			int firstNonBlackYPixelIndex = -1;
@@ -103,6 +143,7 @@ namespace hyperion
 					break;
 				}
 			}
+*/
 
 			// Construct result
 			BlackBorder detectedBorder;

--- a/include/blackborder/BlackBorderDetector.h
+++ b/include/blackborder/BlackBorderDetector.h
@@ -65,6 +65,8 @@ namespace hyperion
 			// only test the topleft third of the image
 			int width = image.width() / 3;
 			int height = image.height() / 3;
+			int width2 = width * 2;
+			int height2 = height * 2;
 			int xCenter = image.width() / 2;
 			int yCenter = image.height() / 2;
 //			int maxSize = std::max(width, height);
@@ -77,8 +79,10 @@ namespace hyperion
 			// find first X pixel of the image
 			for (int x = 0; x < width; ++x)
 			{
-				const Pixel_T & color = image(x, yCenter);
-				if (!isBlack(color))
+				const Pixel_T & color1 = image(x, yCenter);
+				const Pixel_T & color2 = image(x, height);
+				const Pixel_T & color3 = image(x, height2);
+				if (!isBlack(color1) || !isBlack(color2) || !isBlack(color3))
 				{
 					firstNonBlackXPixelIndex = x;
 					break;
@@ -88,8 +92,10 @@ namespace hyperion
 			// find first Y pixel of the image
 			for (int y = 0; y < height; ++y)
 			{
-				const Pixel_T & color = image(xCenter, y);
-				if (!isBlack(color))
+				const Pixel_T & color1 = image(xCenter, y);
+				const Pixel_T & color2 = image(width, y);
+				const Pixel_T & color3 = image(width2, y);
+				if (!isBlack(color1) || !isBlack(color2) || !isBlack(color3))
 				{
 					firstNonBlackYPixelIndex = y;
 					break;

--- a/include/blackborder/BlackBorderDetector.h
+++ b/include/blackborder/BlackBorderDetector.h
@@ -62,15 +62,13 @@ namespace hyperion
 		BlackBorder process(const Image<Pixel_T> & image)
 		{
 
-			// only test the topleft third of the image
+			// test center and 1/3, 2/3 of width/heigth
 			int width = image.width() / 3;
 			int height = image.height() / 3;
 			int width2 = width * 2;
 			int height2 = height * 2;
 			int xCenter = image.width() / 2;
 			int yCenter = image.height() / 2;
-//			int maxSize = std::max(width, height);
-
 
 
 			int firstNonBlackXPixelIndex = -1;
@@ -101,55 +99,6 @@ namespace hyperion
 					break;
 				}
 			}
-
-
-
-/*
-			// only test the topleft third of the image
-			int width = image.width() /3;
-			int height = image.height() / 3;
-			int maxSize = std::max(width, height);
-
-
-
-			int firstNonBlackXPixelIndex = -1;
-			int firstNonBlackYPixelIndex = -1;
-
-			// find some pixel of the image
-			for (int i = 0; i < maxSize; ++i)
-			{
-				int x = std::min(i, width);
-				int y = std::min(i, height);
-
-				const Pixel_T & color = image(x, y);
-				if (!isBlack(color))
-				{
-					firstNonBlackXPixelIndex = x;
-					firstNonBlackYPixelIndex = y;
-					break;
-				}
-			}
-
-			// expand image to the left
-			for(; firstNonBlackXPixelIndex > 0; --firstNonBlackXPixelIndex)
-			{
-				const Pixel_T & color = image(firstNonBlackXPixelIndex-1, firstNonBlackYPixelIndex);
-				if (isBlack(color))
-				{
-					break;
-				}
-			}
-
-			// expand image to the top
-			for(; firstNonBlackYPixelIndex > 0; --firstNonBlackYPixelIndex)
-			{
-				const Pixel_T & color = image(firstNonBlackXPixelIndex, firstNonBlackYPixelIndex-1);
-				if (isBlack(color))
-				{
-					break;
-				}
-			}
-*/
 
 			// Construct result
 			BlackBorder detectedBorder;

--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -89,18 +89,14 @@ namespace hyperion
 		BlackBorderDetector _detector;
 
 		/// The current detected border
-		BlackBorder _currentBorder1;
 		BlackBorder _currentBorder;
 
 		/// The border detected in the previous frame
-		BlackBorder _previousDetectedBorder1;
 		BlackBorder _previousDetectedBorder;
 
 		/// The number of frame the previous detected border matched the incomming border
-		unsigned _consistentCnt1;
 		unsigned _consistentCnt;
 		/// The number of frame the previous detected border NOT matched the incomming border
-		unsigned _inconsistentCnt1;
 		unsigned _inconsistentCnt;
 	};
 } // end namespace hyperion

--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -73,6 +73,8 @@ namespace hyperion
 		/// @return True if the current border changed else false
 		///
 		bool updateBorder(const BlackBorder & newDetectedBorder);
+		bool updateBorder1(const BlackBorder & newDetectedBorder);
+		bool updateBorder2(const BlackBorder & newDetectedBorder);
 
 		/// The number of unknown-borders detected before it becomes the current border
 		const unsigned _unknownSwitchCnt;
@@ -87,12 +89,18 @@ namespace hyperion
 		BlackBorderDetector _detector;
 
 		/// The current detected border
+		BlackBorder _currentBorder1;
 		BlackBorder _currentBorder;
 
 		/// The border detected in the previous frame
+		BlackBorder _previousDetectedBorder1;
 		BlackBorder _previousDetectedBorder;
 
 		/// The number of frame the previous detected border matched the incomming border
+		unsigned _consistentCnt1;
 		unsigned _consistentCnt;
+		/// The number of frame the previous detected border NOT matched the incomming border
+		unsigned _inconsistentCnt1;
+		unsigned _inconsistentCnt;
 	};
 } // end namespace hyperion

--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -73,8 +73,6 @@ namespace hyperion
 		/// @return True if the current border changed else false
 		///
 		bool updateBorder(const BlackBorder & newDetectedBorder);
-		bool updateBorder1(const BlackBorder & newDetectedBorder);
-		bool updateBorder2(const BlackBorder & newDetectedBorder);
 
 		/// The number of unknown-borders detected before it becomes the current border
 		const unsigned _unknownSwitchCnt;

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -1,4 +1,4 @@
-//#include <iostream>
+#include <iostream>
 // Blackborder includes
 #include <blackborder/BlackBorderProcessor.h>
 
@@ -12,9 +12,14 @@ BlackBorderProcessor::BlackBorderProcessor(const unsigned unknownFrameCnt,
 	_borderSwitchCnt(borderFrameCnt),
 	_blurRemoveCnt(blurRemoveCnt),
 	_detector(blackborderThreshold),
+	_currentBorder1({true, -1, -1}),
 	_currentBorder({true, -1, -1}),
+	_previousDetectedBorder1({true, -1, -1}),
 	_previousDetectedBorder({true, -1, -1}),
-	_consistentCnt(0)
+	_consistentCnt1(0),
+	_consistentCnt(0),
+	_inconsistentCnt1(0),
+	_inconsistentCnt(0)
 {
 	// empty
 }
@@ -24,23 +29,102 @@ BlackBorder BlackBorderProcessor::getCurrentBorder() const
 	return _currentBorder;
 }
 
+
 bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
+{
+bool result1 = updateBorder1(newDetectedBorder);
+if (result1)
+{
+	std::cout << "border change v1 " << _currentBorder1.horizontalSize << ":" << _currentBorder1.verticalSize << std::endl;
+}
+
+bool result2 = updateBorder2(newDetectedBorder);
+if (result2)
+{
+	std::cout << "border change v2 " << _currentBorder.horizontalSize << ":" << _currentBorder.verticalSize << std::endl;
+}
+
+return result2;
+}
+
+
+bool BlackBorderProcessor::updateBorder1(const BlackBorder & newDetectedBorder)
+{
+	// set the consistency counter
+	if (newDetectedBorder == _previousDetectedBorder1)
+	{
+		++_consistentCnt1;
+	}
+	else
+	{
+		_previousDetectedBorder1 = newDetectedBorder;
+		_consistentCnt1          = 0;
+	}
+
+//	std::cout << "cur: " << _currentBorder1.verticalSize << " " << _currentBorder1.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt1 << ":" << _inconsistentCnt1 << std::endl;
+
+	// check if there is a change
+	if (_currentBorder1 == newDetectedBorder)
+	{
+		// No change required
+		return false;
+	}
+
+	bool borderChanged = false;
+	if (newDetectedBorder.unknown)
+	{
+		// apply the unknown border if we consistently can't determine a border
+		if (_consistentCnt1 == _unknownSwitchCnt)
+		{
+			_currentBorder1 = newDetectedBorder;
+			borderChanged = true;
+		}
+	}
+	else
+	{
+		// apply the detected border if it has been detected consistently
+		if (_currentBorder1.unknown || _consistentCnt1 == _borderSwitchCnt)
+		{
+			_currentBorder1 = newDetectedBorder;
+			borderChanged = true;
+		}
+		else
+		{
+			bool stable = (_consistentCnt >= 10) || (_inconsistentCnt >=30 );
+			// apply smaller borders immediately
+			if ((newDetectedBorder.verticalSize < _currentBorder1.verticalSize) && (stable))
+			{
+				_currentBorder1.verticalSize = newDetectedBorder.verticalSize;
+				borderChanged = true;
+			}
+
+			if ((newDetectedBorder.horizontalSize < _currentBorder1.horizontalSize) && (stable))
+			{
+				_currentBorder1.horizontalSize = newDetectedBorder.horizontalSize;
+				borderChanged = true;
+			}
+		}
+	}
+
+	return borderChanged;
+}
+
+bool BlackBorderProcessor::updateBorder2(const BlackBorder & newDetectedBorder)
 {
 	// set the consistency counter
 	if (newDetectedBorder == _previousDetectedBorder)
 	{
-		if (_consistentCnt < 100000)
-		{
-			++_consistentCnt;
-		}
+		++_consistentCnt;
+		_inconsistentCnt         = 0;
 	}
 	else
 	{
 		_previousDetectedBorder = newDetectedBorder;
 		_consistentCnt          = 0;
+		++_inconsistentCnt;
 	}
 
-//	std::cout << "new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " cc " << _consistentCnt << std::endl;
+//	std::cout << "cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt << ":" << _inconsistentCnt << std::endl;
 
 	// check if there is a change
 	if (_currentBorder == newDetectedBorder)
@@ -71,16 +155,19 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 		}
 		else
 		{
+			bool stable = (_consistentCnt >= 10) || (_inconsistentCnt >=30 );
+										//more then A consistent seems like a new size not only a short flicker 
+										//more then B inconsistent seems like the image is changing a lot and we need to set smaller border
 			// apply smaller borders immediately
 //			if (newDetectedBorder.verticalSize < _currentBorder.verticalSize)
-			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (_consistentCnt >= 1) )// almost immediatly - avoid switching for "abnormal" frames
+			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (stable) )// almost immediatly - avoid switching for "abnormal" frames
 			{
 				_currentBorder.verticalSize = newDetectedBorder.verticalSize;
 				borderChanged = true;
 			}
 
 //			if (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize)
-			if ( (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize) && (_consistentCnt >= 1) )
+			if ( (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize) && (stable) )
 			{
 				_currentBorder.horizontalSize = newDetectedBorder.horizontalSize;
 				borderChanged = true;

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -51,8 +51,7 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	if (newDetectedBorder.unknown)
 	{
 		// apply the unknown border if we consistently can't determine a border
-//		if (_consistentCnt == _unknownSwitchCnt)
-		if (_consistentCnt >= _unknownSwitchCnt)
+		if (_consistentCnt == _unknownSwitchCnt)
 		{
 			_currentBorder = newDetectedBorder;
 			borderChanged = true;
@@ -61,8 +60,7 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	else
 	{
 		// apply the detected border if it has been detected consistently
-//		if (_currentBorder.unknown || _consistentCnt == _borderSwitchCnt)
-		if (_currentBorder.unknown || _consistentCnt >= _borderSwitchCnt)
+		if (_currentBorder.unknown || _consistentCnt == _borderSwitchCnt)
 		{
 			_currentBorder = newDetectedBorder;
 			borderChanged = true;
@@ -70,17 +68,16 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 		else
 		{
 			bool stable = (_consistentCnt >= 10) || (_inconsistentCnt >=30 );
-										//more then A consistent seems like a new size not only a short flicker 
-										//more then B inconsistent seems like the image is changing a lot and we need to set smaller border
-			// apply smaller borders immediately
-//			if (newDetectedBorder.verticalSize < _currentBorder.verticalSize)
-			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (stable) )// almost immediatly - avoid switching for "abnormal" frames
+			//more then 10 consistent seems like a new size not only a short flicker 
+			//more then 30 inconsistent seems like the image is changing a lot and we need to set smaller border
+
+			// apply smaller borders (almost) immediately -> avoid switching for "abnormal" frames
+			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (stable) )
 			{
 				_currentBorder.verticalSize = newDetectedBorder.verticalSize;
 				borderChanged = true;
 			}
 
-//			if (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize)
 			if ( (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize) && (stable) )
 			{
 				_currentBorder.horizontalSize = newDetectedBorder.horizontalSize;

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+
 // Blackborder includes
 #include <blackborder/BlackBorderProcessor.h>
 
@@ -12,13 +12,9 @@ BlackBorderProcessor::BlackBorderProcessor(const unsigned unknownFrameCnt,
 	_borderSwitchCnt(borderFrameCnt),
 	_blurRemoveCnt(blurRemoveCnt),
 	_detector(blackborderThreshold),
-	_currentBorder1({true, -1, -1}),
 	_currentBorder({true, -1, -1}),
-	_previousDetectedBorder1({true, -1, -1}),
 	_previousDetectedBorder({true, -1, -1}),
-	_consistentCnt1(0),
 	_consistentCnt(0),
-	_inconsistentCnt1(0),
 	_inconsistentCnt(0)
 {
 	// empty
@@ -29,87 +25,7 @@ BlackBorder BlackBorderProcessor::getCurrentBorder() const
 	return _currentBorder;
 }
 
-
 bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
-{
-bool result1 = updateBorder1(newDetectedBorder);
-if (result1)
-{
-	std::cout << "border change v1 " << _currentBorder1.horizontalSize << ":" << _currentBorder1.verticalSize << std::endl;
-}
-
-bool result2 = updateBorder2(newDetectedBorder);
-if (result2)
-{
-	std::cout << "border change v2 " << _currentBorder.horizontalSize << ":" << _currentBorder.verticalSize << std::endl;
-}
-
-return result2;
-}
-
-
-bool BlackBorderProcessor::updateBorder1(const BlackBorder & newDetectedBorder)
-{
-	// set the consistency counter
-	if (newDetectedBorder == _previousDetectedBorder1)
-	{
-		++_consistentCnt1;
-	}
-	else
-	{
-		_previousDetectedBorder1 = newDetectedBorder;
-		_consistentCnt1          = 0;
-	}
-
-//	std::cout << "cur: " << _currentBorder1.verticalSize << " " << _currentBorder1.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt1 << ":" << _inconsistentCnt1 << std::endl;
-
-	// check if there is a change
-	if (_currentBorder1 == newDetectedBorder)
-	{
-		// No change required
-		return false;
-	}
-
-	bool borderChanged = false;
-	if (newDetectedBorder.unknown)
-	{
-		// apply the unknown border if we consistently can't determine a border
-		if (_consistentCnt1 == _unknownSwitchCnt)
-		{
-			_currentBorder1 = newDetectedBorder;
-			borderChanged = true;
-		}
-	}
-	else
-	{
-		// apply the detected border if it has been detected consistently
-		if (_currentBorder1.unknown || _consistentCnt1 == _borderSwitchCnt)
-		{
-			_currentBorder1 = newDetectedBorder;
-			borderChanged = true;
-		}
-		else
-		{
-			bool stable = (_consistentCnt >= 10) || (_inconsistentCnt >=30 );
-			// apply smaller borders immediately
-			if ((newDetectedBorder.verticalSize < _currentBorder1.verticalSize) && (stable))
-			{
-				_currentBorder1.verticalSize = newDetectedBorder.verticalSize;
-				borderChanged = true;
-			}
-
-			if ((newDetectedBorder.horizontalSize < _currentBorder1.horizontalSize) && (stable))
-			{
-				_currentBorder1.horizontalSize = newDetectedBorder.horizontalSize;
-				borderChanged = true;
-			}
-		}
-	}
-
-	return borderChanged;
-}
-
-bool BlackBorderProcessor::updateBorder2(const BlackBorder & newDetectedBorder)
 {
 	// set the consistency counter
 	if (newDetectedBorder == _previousDetectedBorder)
@@ -123,8 +39,6 @@ bool BlackBorderProcessor::updateBorder2(const BlackBorder & newDetectedBorder)
 		_consistentCnt          = 0;
 		++_inconsistentCnt;
 	}
-
-//	std::cout << "cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt << ":" << _inconsistentCnt << std::endl;
 
 	// check if there is a change
 	if (_currentBorder == newDetectedBorder)

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -1,4 +1,4 @@
-
+//#include <iostream>
 // Blackborder includes
 #include <blackborder/BlackBorderProcessor.h>
 
@@ -29,13 +29,18 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	// set the consistency counter
 	if (newDetectedBorder == _previousDetectedBorder)
 	{
-		++_consistentCnt;
+		if (_consistentCnt < 100000)
+		{
+			++_consistentCnt;
+		}
 	}
 	else
 	{
 		_previousDetectedBorder = newDetectedBorder;
 		_consistentCnt          = 0;
 	}
+
+//	std::cout << "new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " cc " << _consistentCnt << std::endl;
 
 	// check if there is a change
 	if (_currentBorder == newDetectedBorder)
@@ -48,7 +53,8 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	if (newDetectedBorder.unknown)
 	{
 		// apply the unknown border if we consistently can't determine a border
-		if (_consistentCnt == _unknownSwitchCnt)
+//		if (_consistentCnt == _unknownSwitchCnt)
+		if (_consistentCnt >= _unknownSwitchCnt)
 		{
 			_currentBorder = newDetectedBorder;
 			borderChanged = true;
@@ -57,7 +63,8 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	else
 	{
 		// apply the detected border if it has been detected consistently
-		if (_currentBorder.unknown || _consistentCnt == _borderSwitchCnt)
+//		if (_currentBorder.unknown || _consistentCnt == _borderSwitchCnt)
+		if (_currentBorder.unknown || _consistentCnt >= _borderSwitchCnt)
 		{
 			_currentBorder = newDetectedBorder;
 			borderChanged = true;
@@ -65,13 +72,15 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 		else
 		{
 			// apply smaller borders immediately
-			if (newDetectedBorder.verticalSize < _currentBorder.verticalSize)
+//			if (newDetectedBorder.verticalSize < _currentBorder.verticalSize)
+			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (_consistentCnt >= 1) )// almost immediatly - avoid switching for "abnormal" frames
 			{
 				_currentBorder.verticalSize = newDetectedBorder.verticalSize;
 				borderChanged = true;
 			}
 
-			if (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize)
+//			if (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize)
+			if ( (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize) && (_consistentCnt >= 1) )
 			{
 				_currentBorder.horizontalSize = newDetectedBorder.horizontalSize;
 				borderChanged = true;


### PR DESCRIPTION
blackborderprocessor:
added a tolerance for switching to smaller border. will prevent a lot of false positives resulting from size decimation/bad signal/flickering.
blackborderdetector:
changed the way the border is detected - the function will try check vertical and horizonal separate and check at 1/3 1/2 and 2/3 of the width/height (3 pixel check) till it finds a non black pixel
which will also decrease the number of false positives.
will use a little bit more resources but seems more stable in the end