### PR TITLE
Blackborder Improved +

### DIFF
--- a/include/blackborder/BlackBorderDetector.h
+++ b/include/blackborder/BlackBorderDetector.h
@@ -62,13 +62,17 @@ namespace hyperion
 		BlackBorder process(const Image<Pixel_T> & image)
 		{
 
-			// test center and 1/3, 2/3 of width/heigth
-			int width = image.width() / 3;
-			int height = image.height() / 3;
-			int width2 = width * 2;
-			int height2 = height * 2;
-			int xCenter = image.width() / 2;
-			int yCenter = image.height() / 2;
+			// test center and 33%, 66% of width/heigth
+			// 33 and 66 will check left and top
+			// center ill check right and bottom sids
+			int width = image.width();
+			int height = image.height();
+			int width33percent = width / 3;
+			int height33percent = height / 3;
+			int width66percent = width33percent * 2;
+			int height66percent = height33percent * 2;
+			int xCenter = width / 2;
+			int yCenter = height / 2;
 
 
 			int firstNonBlackXPixelIndex = -1;
@@ -77,9 +81,9 @@ namespace hyperion
 			// find first X pixel of the image
 			for (int x = 0; x < width; ++x)
 			{
-				const Pixel_T & color1 = image(x, yCenter);
-				const Pixel_T & color2 = image(x, height);
-				const Pixel_T & color3 = image(x, height2);
+				const Pixel_T & color1 = image( (width - x), yCenter); // right side center line check
+				const Pixel_T & color2 = image(x, height33percent);
+				const Pixel_T & color3 = image(x, height66percent);
 				if (!isBlack(color1) || !isBlack(color2) || !isBlack(color3))
 				{
 					firstNonBlackXPixelIndex = x;
@@ -90,9 +94,9 @@ namespace hyperion
 			// find first Y pixel of the image
 			for (int y = 0; y < height; ++y)
 			{
-				const Pixel_T & color1 = image(xCenter, y);
-				const Pixel_T & color2 = image(width, y);
-				const Pixel_T & color3 = image(width2, y);
+				const Pixel_T & color1 = image(xCenter, (height - y)); // bottom center line check
+				const Pixel_T & color2 = image(width33percent, y );
+				const Pixel_T & color3 = image(width66percent, y);
 				if (!isBlack(color1) || !isBlack(color2) || !isBlack(color3))
 				{
 					firstNonBlackYPixelIndex = y;

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+//#include <iostream>
 
 // Blackborder includes
 #include <blackborder/BlackBorderProcessor.h>
@@ -39,7 +39,7 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 // makes it look like the border detectionn is not working - since the new 3 line detection algorithm is more precise this became a problem specialy in dark scenes
 // wisc
 
-	std::cout << "cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt << ":" << _inconsistentCnt << std::endl;
+//	std::cout << "cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt << ":" << _inconsistentCnt << std::endl;
 
 	// set the consistency counter
 	if (newDetectedBorder == _previousDetectedBorder)

--- a/libsrc/blackborder/BlackBorderProcessor.cpp
+++ b/libsrc/blackborder/BlackBorderProcessor.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 
 // Blackborder includes
 #include <blackborder/BlackBorderProcessor.h>
@@ -15,7 +16,7 @@ BlackBorderProcessor::BlackBorderProcessor(const unsigned unknownFrameCnt,
 	_currentBorder({true, -1, -1}),
 	_previousDetectedBorder({true, -1, -1}),
 	_consistentCnt(0),
-	_inconsistentCnt(0)
+	_inconsistentCnt(10)
 {
 	// empty
 }
@@ -27,6 +28,19 @@ BlackBorder BlackBorderProcessor::getCurrentBorder() const
 
 bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 {
+// the new changes ignore false small borders (no reset of consistance)
+// as long as the previous stable state returns within 10 frames
+// and will only switch to a new border if it is realy detected stable >50 frames
+
+// sometimes the grabber delivers "bad" frames with a smaller black border (looks like random number every few frames and even when freezing the image)
+// maybe some interferences of the power supply or bad signal causing this effect - not exactly sure what causes it but changing the power supply of the converter significantly increased that "random" effect on my system
+// (you can check with the debug output below or if you want i can provide some output logs)
+// this "random effect" caused the old algorithm to switch to that smaller border immediatly, resulting in a too small border being detected
+// makes it look like the border detectionn is not working - since the new 3 line detection algorithm is more precise this became a problem specialy in dark scenes
+// wisc
+
+	std::cout << "cur: " << _currentBorder.verticalSize << " " << _currentBorder.horizontalSize << " new: " << newDetectedBorder.verticalSize << " " << newDetectedBorder.horizontalSize << " c:i " << _consistentCnt << ":" << _inconsistentCnt << std::endl;
+
 	// set the consistency counter
 	if (newDetectedBorder == _previousDetectedBorder)
 	{
@@ -35,15 +49,23 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 	}
 	else
 	{
+		++_inconsistentCnt;
+		if (_inconsistentCnt <= 10)// few inconsistent frames
+		{
+			//discard the newDetectedBorder -> keep the consistent count for previousDetectedBorder
+			return false;
+		}
+		// the inconsistency threshold is reached
+		// -> give the newDetectedBorder a chance to proof that its consistent
 		_previousDetectedBorder = newDetectedBorder;
 		_consistentCnt          = 0;
-		++_inconsistentCnt;
 	}
 
 	// check if there is a change
 	if (_currentBorder == newDetectedBorder)
 	{
 		// No change required
+		_inconsistentCnt = 0; // we have found a consistent border -> reset _inconsistentCnt
 		return false;
 	}
 
@@ -64,25 +86,6 @@ bool BlackBorderProcessor::updateBorder(const BlackBorder & newDetectedBorder)
 		{
 			_currentBorder = newDetectedBorder;
 			borderChanged = true;
-		}
-		else
-		{
-			bool stable = (_consistentCnt >= 10) || (_inconsistentCnt >=30 );
-			//more then 10 consistent seems like a new size not only a short flicker 
-			//more then 30 inconsistent seems like the image is changing a lot and we need to set smaller border
-
-			// apply smaller borders (almost) immediately -> avoid switching for "abnormal" frames
-			if ( (newDetectedBorder.verticalSize < _currentBorder.verticalSize) && (stable) )
-			{
-				_currentBorder.verticalSize = newDetectedBorder.verticalSize;
-				borderChanged = true;
-			}
-
-			if ( (newDetectedBorder.horizontalSize < _currentBorder.horizontalSize) && (stable) )
-			{
-				_currentBorder.horizontalSize = newDetectedBorder.horizontalSize;
-				borderChanged = true;
-			}
 		}
 	}
 

--- a/test/TestBlackBorderProcessor.cpp
+++ b/test/TestBlackBorderProcessor.cpp
@@ -29,7 +29,7 @@ Image<ColorRgb> createImage(unsigned width, unsigned height, unsigned topBorder,
 	{
 		for (unsigned y=0; y<image.height(); ++y)
 		{
-			if (y < topBorder || x < leftBorder)
+			if (y < topBorder || y > ( height - topBorder ) || x < leftBorder || x > (width - leftBorder) )
 			{
 				image(x,y) = ColorRgb::BLACK;
 			}
@@ -86,7 +86,7 @@ int main()
 	for (unsigned i=0; i<borderCnt*2; ++i)
 	{
 		bool newBorder = processor.process(horzImage);
-		if (i == borderCnt)
+		if (i == borderCnt+10)// 10 frames till new border gets a chance to proof consistency
 		{
 			if (!newBorder)
 			{
@@ -111,18 +111,42 @@ int main()
 		exit(EXIT_FAILURE);
 	}
 
-	// Switch back (in one shot) to no border
-	if (!processor.process(noBorderImage) || (processor.getCurrentBorder().unknown != false || processor.getCurrentBorder().horizontalSize != 0 || processor.getCurrentBorder().verticalSize != 0))
+	for (unsigned i=0; i<borderCnt*2; ++i)
 	{
-		std::cerr << "Failed to switch back to 'no border' with one image" << std::endl;
-		exit(EXIT_FAILURE);
+
+		bool newBorder = processor.process(noBorderImage);
+		if (i == borderCnt+10)// 10 frames till new border gets a chance to proof consistency
+		{
+			if (!newBorder)
+			{
+				std::cerr << "Failed to detect 'no border' when required after " << borderCnt << " images" << std::endl;
+				exit(EXIT_FAILURE);
+			}
+		}
+		else
+		{
+			if (newBorder)
+			{
+				std::cerr << "Incorrectly detected no border, when there in none" << std::endl;
+				exit(EXIT_FAILURE);
+			}
+		}
 	}
+
+		// Check switch back to no border
+		if ( (processor.getCurrentBorder().unknown != false || processor.getCurrentBorder().horizontalSize != 0 || processor.getCurrentBorder().verticalSize != 0))
+		{
+			std::cerr << "Failed to switch back to 'no border'" << std::endl;
+			exit(EXIT_FAILURE);
+		}
+
+
 
 	Image<ColorRgb> vertImage = createImage(64, 64, 0, borderSize);
 	for (unsigned i=0; i<borderCnt*2; ++i)
 	{
 		bool newBorder = processor.process(vertImage);
-		if (i == borderCnt)
+		if (i == borderCnt+10)// 10 frames till new border gets a chance to proof consistency
 		{
 			if (!newBorder)
 			{
@@ -147,8 +171,8 @@ int main()
 	}
 
 	// Switch back (in one shot) to no border
-	assert(processor.process(noBorderImage));
-	assert(processor.getCurrentBorder().verticalSize == 0 && processor.getCurrentBorder().horizontalSize == 0);
+//	assert(processor.process(noBorderImage));
+//	assert(processor.getCurrentBorder().verticalSize == 0 && processor.getCurrentBorder().horizontalSize == 0);
 
 	return 0;
 }


### PR DESCRIPTION
BlackBorderProcessor.cpp:
The new changes ignore false small borders (no reset of consistance)
as long as the previous stable state returns within 10 frames
and will only switch to a new border if it is realy detected stable >50 frames.
More information in sourcecode

BlackBorderDetector.h:
Still checking 3 lines horizontal and vertical.
But instead of checking only left and top the center "scanlines" will check bottom and right side of the image to avoid detecting small border when there is only a dark area on the left side or the top area of the image.