### PR TITLE
make priority of boot effect adjustable.

### DIFF
--- a/config/hyperion.config.json
+++ b/config/hyperion.config.json
@@ -364,7 +364,10 @@
 	/// The configuration of the effect engine, contains the following items: 
 	///  * paths        : An array with absolute location(s) of directories with effects 
 	///  * bootsequence : The effect selected as 'boot sequence'
+	///    * effect : name of the effect you want to start. Set to empty if no effect wanted
+	///    * color  : switch to static color after effect is done
 	///    * duration_ms : duration of boot effect in ms. 0 means effect stays forever
+	///    * priority : priority of boot effect and static color
 	"effects" : 
 	{
 		"paths" : 
@@ -375,6 +378,7 @@
 
 	"bootsequence" : 
 	{
+		"color"       : [0,0,0],
 		"effect"      : "Rainbow swirl fast",
 		"duration_ms" : 3000,
 		"priority"    : 0

--- a/config/hyperion.config.json
+++ b/config/hyperion.config.json
@@ -364,6 +364,7 @@
 	/// The configuration of the effect engine, contains the following items: 
 	///  * paths        : An array with absolute location(s) of directories with effects 
 	///  * bootsequence : The effect selected as 'boot sequence'
+	///    * duration_ms : duration of boot effect in ms. 0 means effect stays forever
 	"effects" : 
 	{
 		"paths" : 
@@ -374,8 +375,9 @@
 
 	"bootsequence" : 
 	{
-		"effect" : "Rainbow swirl fast",
-		"duration_ms" : 3000
+		"effect"      : "Rainbow swirl fast",
+		"duration_ms" : 3000,
+		"priority"    : 0
 	},
 
 	///  The configuration for the frame-grabber, contains the following items: 

--- a/config/hyperion_x86.config.json
+++ b/config/hyperion_x86.config.json
@@ -359,6 +359,7 @@
 	/// The configuration of the effect engine, contains the following items: 
 	///  * paths        : An array with absolute location(s) of directories with effects 
 	///  * bootsequence : The effect selected as 'boot sequence'
+	///    * duration_ms : duration of boot effect in ms. 0 means effect stays forever
 	"effects" : 
 	{
 		"paths" : 
@@ -369,8 +370,9 @@
 
 	"bootsequence" : 
 	{
-		"effect" : "Rainbow swirl fast",
-		"duration_ms" : 3000
+		"effect"      : "Rainbow swirl fast",
+		"duration_ms" : 3000,
+		"priority"    : 0
 	},
 
 	///  The configuration for the frame-grabber, contains the following items: 

--- a/config/hyperion_x86.config.json
+++ b/config/hyperion_x86.config.json
@@ -359,7 +359,10 @@
 	/// The configuration of the effect engine, contains the following items: 
 	///  * paths        : An array with absolute location(s) of directories with effects 
 	///  * bootsequence : The effect selected as 'boot sequence'
+	///    * effect : name of the effect you want to start. Set to empty if no effect wanted
+	///    * color  : switch to static color after effect is done
 	///    * duration_ms : duration of boot effect in ms. 0 means effect stays forever
+	///    * priority : priority of boot effect and static color
 	"effects" : 
 	{
 		"paths" : 
@@ -370,9 +373,10 @@
 
 	"bootsequence" : 
 	{
+		"color"       : [0,0,0],
 		"effect"      : "Rainbow swirl fast",
 		"duration_ms" : 3000,
-		"priority"    : 0
+		"priority"    : 900
 	},
 
 	///  The configuration for the frame-grabber, contains the following items: 

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
 		// Get the parameters for the bootsequence
 		const std::string effectName = effectConfig["effect"].asString();
 		const unsigned duration_ms   = effectConfig["duration_ms"].asUInt();
-		const int priority = 0;
+		const int priority           = effectConfig["priority"].asUInt();
 
 		hyperion.setColor(priority+1, ColorRgb::BLACK, duration_ms, false);
 

--- a/src/hyperiond/hyperiond.cpp
+++ b/src/hyperiond/hyperiond.cpp
@@ -127,19 +127,33 @@ int main(int argc, char** argv)
 		const std::string effectName = effectConfig["effect"].asString();
 		const unsigned duration_ms   = effectConfig["duration_ms"].asUInt();
 		const int priority           = effectConfig["priority"].asUInt();
+		const int bootcolor_priority = (priority > 990) ? priority+1 : 990;
 
-		hyperion.setColor(priority+1, ColorRgb::BLACK, duration_ms, false);
+		if ( ! effectConfig["color"].isNull() && effectConfig["color"].isArray() && effectConfig["color"].size() == 3 )
+		{
+			ColorRgb boot_color = {
+				(uint8_t)effectConfig["color"][0].asUInt(),
+				(uint8_t)effectConfig["color"][1].asUInt(),
+				(uint8_t)effectConfig["color"][2].asUInt()
+			};
+
+			hyperion.setColor(bootcolor_priority, boot_color, 0, false);
+		}
+		else
+		{
+			hyperion.setColor(bootcolor_priority, ColorRgb::BLACK, duration_ms, false);
+		}
 
 		if (effectConfig.isMember("args"))
 		{
 			const Json::Value effectConfigArgs = effectConfig["args"];
 			if (hyperion.setEffect(effectName, effectConfigArgs, priority, duration_ms) == 0)
 			{
-					std::cout << "Boot sequence(" << effectName << ") with user-defined arguments created and started" << std::endl;
+				std::cout << "Boot sequence(" << effectName << ") with user-defined arguments created and started" << std::endl;
 			}
 			else
 			{
-					std::cout << "Failed to start boot sequence: " << effectName << " with user-defined arguments" << std::endl;
+				std::cout << "Failed to start boot sequence: " << effectName << " with user-defined arguments" << std::endl;
 			}
 		}
 		else


### PR DESCRIPTION
When boot effect is set to "stay forever" (duration 0), no effect can't be set afterwards.
Now it is settable in config and everybody can set the value to something that fits the needs.

this PR should fullfill @solidewebservices issue in issue #437 and is usefull for issue #77 too