### PR TITLE
Blackborder Improved + (bugfix and enhancement)

### DIFF
--- a/config/hyperion.config.json
+++ b/config/hyperion.config.json
@@ -355,10 +355,21 @@
 	/// The black border configuration, contains the following items: 
 	///  * enable    : true if the detector should be activated
 	///  * threshold : Value below which a pixel is regarded as black (value between 0.0 and 1.0)
-	"blackborderdetector" : 
+	///  * unknownFrameCnt : Number of frames without any detection before the border is set to 0 (default 600) - optional
+	///  * borderFrameCnt : Number of frames before a consistent detected border gets set (default 50) - optional
+	///  * maxInconsistentCnt : Number of inconsistent frames that are ignored before a new border gets a chance to proof consistency - optional
+	///  * blurRemoveCnt : Number of pixels that get removed from the detected border to cut away blur (default 1) - optional
+	///  * mode : Border detection mode (values "default","classic","osd") - optional
+	
+	"blackborderdetector" :
 	{
 		"enable" : true,
-		"threshold" : 0.01
+		"threshold" : 0.01,
+		"unknownFrameCnt": 600,
+		"borderFrameCnt" : 50,
+		"maxInconsistentCnt" : 10,
+		"blurRemoveCnt": 1,
+		"mode" : "default"
 	},
 
 	/// The configuration of the effect engine, contains the following items: 

--- a/include/blackborder/BlackBorderProcessor.h
+++ b/include/blackborder/BlackBorderProcessor.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+// Jsoncpp includes
+#include <json/json.h>
 // Local Hyperion includes
 #include "BlackBorderDetector.h"
 
@@ -23,11 +25,7 @@ namespace hyperion
 		///                      outer pixels is blurred (black and color combined due to image scaling))
 		/// @param[in] blackborderThreshold The threshold which the blackborder detector should use
 		///
-		BlackBorderProcessor(
-				const unsigned unknownFrameCnt,
-				const unsigned borderFrameCnt,
-				const unsigned blurRemoveCnt,
-				uint8_t blackborderThreshold);
+		BlackBorderProcessor(const Json::Value &blackborderConfig);
 
 		///
 		/// Return the current (detected) border
@@ -48,7 +46,14 @@ namespace hyperion
 		bool process(const Image<Pixel_T> & image)
 		{
 			// get the border for the single image
-			BlackBorder imageBorder = _detector.process(image);
+			BlackBorder imageBorder;
+			if (_detectionMode == "default") {
+				imageBorder = _detector.process(image);
+			} else if (_detectionMode == "classic") {
+				imageBorder = _detector.process_classic(image);
+			} else if (_detectionMode == "osd") {
+				imageBorder = _detector.process_osd(image);
+			}
 			// add blur to the border
 			if (imageBorder.horizontalSize > 0)
 			{
@@ -80,8 +85,14 @@ namespace hyperion
 		/// The number of horizontal/vertical borders detected before it becomes the current border
 		const unsigned _borderSwitchCnt;
 
+		// The number of frames that are "ignored" before a new border gets set as _previousDetectedBorder
+		const unsigned _maxInconsistentCnt;
+
 		/// The number of pixels to increase a detected border for removing blury pixels
 		unsigned _blurRemoveCnt;
+
+		/// The border detection mode
+		const std::string _detectionMode;
 
 		/// The blackborder detector
 		BlackBorderDetector _detector;
@@ -96,5 +107,6 @@ namespace hyperion
 		unsigned _consistentCnt;
 		/// The number of frame the previous detected border NOT matched the incomming border
 		unsigned _inconsistentCnt;
+
 	};
 } // end namespace hyperion

--- a/include/hyperion/ImageProcessor.h
+++ b/include/hyperion/ImageProcessor.h
@@ -106,7 +106,7 @@ private:
 	/// @param[in] enableBlackBorderDetector Flag indicating if the blacborder detector should be enabled
 	/// @param[in] blackborderThreshold The threshold which the blackborder detector should use
 	///
-	ImageProcessor(const LedString &ledString, bool enableBlackBorderDetector, uint8_t blackborderThreshold);
+	ImageProcessor(const LedString &ledString, const Json::Value &blackborderConfig);
 
 	///
 	/// Performs black-border detection (if enabled) on the given image

--- a/include/hyperion/ImageProcessorFactory.h
+++ b/include/hyperion/ImageProcessorFactory.h
@@ -33,7 +33,7 @@ public:
 	/// @param[in] enableBlackBorderDetector Flag indicating if the blacborder detector should be enabled
 	/// @param[in] blackborderThreshold The threshold which the blackborder detector should use
 	///
-	void init(const LedString& ledString, bool enableBlackBorderDetector, double blackborderThreshold);
+	void init(const LedString& ledString, const Json::Value &blackborderConfig);
 
 	///
 	/// Creates a new ImageProcessor. The onwership of the processor is transferred to the caller.
@@ -46,9 +46,6 @@ private:
 	/// The Led-string specification
 	LedString _ledString;
 
-	/// Flag indicating if the black border detector should be used
-	bool _enableBlackBorderDetector;
-
-	/// Threshold for the blackborder detector [0 .. 255]
-	uint8_t _blackborderThreshold;
+	// Reference to the blackborder json configuration values
+	Json::Value _blackborderConfig;
 };

--- a/libsrc/blackborder/BlackBorderDetector.cpp
+++ b/libsrc/blackborder/BlackBorderDetector.cpp
@@ -1,11 +1,26 @@
-
+#include <iostream>
 // BlackBorders includes
 #include <blackborder/BlackBorderDetector.h>
 
 using namespace hyperion;
 
-BlackBorderDetector::BlackBorderDetector(uint8_t blackborderThreshold) :
-	_blackborderThreshold(blackborderThreshold)
+BlackBorderDetector::BlackBorderDetector(double threshold) :
+	_blackborderThreshold(calculateThreshold(threshold))
 {
 	// empty
+}
+
+uint8_t BlackBorderDetector::calculateThreshold(double threshold)
+{
+	int rgbThreshold = int(std::ceil(threshold * 255));
+	if (rgbThreshold < 0)
+		rgbThreshold = 0;
+	else if (rgbThreshold > 255)
+		rgbThreshold = 255;
+
+	uint8_t blackborderThreshold = uint8_t(rgbThreshold);
+
+	std::cout << "Black border threshold set to " << threshold << " (" << int(blackborderThreshold) << ")" << std::endl;
+
+	return blackborderThreshold;
 }

--- a/libsrc/hyperion/Hyperion.cpp
+++ b/libsrc/hyperion/Hyperion.cpp
@@ -282,8 +282,8 @@ Hyperion::Hyperion(const Json::Value &jsonConfig) :
 	// initialize the image processor factory
 	ImageProcessorFactory::getInstance().init(
 				_ledString,
-				jsonConfig["blackborderdetector"].get("enable", true).asBool(),
-				jsonConfig["blackborderdetector"].get("threshold", 0.01).asDouble());
+				jsonConfig["blackborderdetector"]
+	);
 
 	// initialize the color smoothing filter
 	_device = createColorSmoothing(jsonConfig["color"]["smoothing"], _device);

--- a/libsrc/hyperion/ImageProcessor.cpp
+++ b/libsrc/hyperion/ImageProcessor.cpp
@@ -8,10 +8,11 @@
 
 using namespace hyperion;
 
-ImageProcessor::ImageProcessor(const LedString& ledString, bool enableBlackBorderDetector, uint8_t blackborderThreshold) :
+//ImageProcessor::ImageProcessor(const LedString& ledString, bool enableBlackBorderDetector, uint8_t blackborderThreshold) :
+ImageProcessor::ImageProcessor(const LedString& ledString, const Json::Value & blackborderConfig) :
 	_ledString(ledString),
-	_enableBlackBorderRemoval(enableBlackBorderDetector),
-	_borderProcessor(new BlackBorderProcessor(600, 50, 1, blackborderThreshold)),
+	_enableBlackBorderRemoval(blackborderConfig.get("enable", true).asBool()),
+	_borderProcessor(new BlackBorderProcessor(blackborderConfig) ),
 	_imageToLeds(nullptr)
 {
 	// empty

--- a/libsrc/hyperion/ImageProcessorFactory.cpp
+++ b/libsrc/hyperion/ImageProcessorFactory.cpp
@@ -13,25 +13,13 @@ ImageProcessorFactory& ImageProcessorFactory::getInstance()
 	return instance;
 }
 
-void ImageProcessorFactory::init(const LedString& ledString, bool enableBlackBorderDetector, double blackborderThreshold)
+void ImageProcessorFactory::init(const LedString& ledString, const Json::Value & blackborderConfig)
 {
 	_ledString = ledString;
-	_enableBlackBorderDetector = enableBlackBorderDetector;
-
-	int threshold = int(std::ceil(blackborderThreshold * 255));
-	if (threshold < 0)
-		threshold = 0;
-	else if (threshold > 255)
-		threshold = 255;
-	_blackborderThreshold = uint8_t(threshold);
-
-	if (_enableBlackBorderDetector)
-	{
-		std::cout << "Black border threshold set to " << blackborderThreshold << " (" << int(_blackborderThreshold) << ")" << std::endl;
-	}
+	_blackborderConfig = blackborderConfig;
 }
 
 ImageProcessor* ImageProcessorFactory::newImageProcessor() const
 {
-	return new ImageProcessor(_ledString, _enableBlackBorderDetector, _blackborderThreshold);
+	return new ImageProcessor(_ledString, _blackborderConfig);
 }

--- a/test/TestBlackBorderProcessor.cpp
+++ b/test/TestBlackBorderProcessor.cpp
@@ -44,11 +44,13 @@ Image<ColorRgb> createImage(unsigned width, unsigned height, unsigned topBorder,
 
 int main()
 {
-	unsigned unknownCnt = 600;
+//	unsigned unknownCnt = 600;
 	unsigned borderCnt  = 50;
-	unsigned blurCnt    = 0;
+//	unsigned blurCnt    = 0;
+	Json::Value config;
 
-	BlackBorderProcessor processor(unknownCnt, borderCnt, blurCnt, 3);
+//	BlackBorderProcessor processor(unknownCnt, borderCnt, blurCnt, 3, config);
+	BlackBorderProcessor processor(config);
 
 	// Start with 'no border' detection
 	Image<ColorRgb> noBorderImage = createImage(64, 64, 0, 0);


### PR DESCRIPTION
fixed a bug that caused undefined behaviour in detection,
causing it to get stuck at 0,0 border detection.

Also made json config accessable in blackborder classes for easy adjusting values that are static in current build.

Added different detection modes.

see config/hyperion.config.json
```
"blackborderdetector" :
 	{
 		"enable" : true,
 		"threshold" : 0.01,
+		"unknownFrameCnt": 600,         <- optional
+		"borderFrameCnt" : 50,          <- optional
+		"maxInconsistentCnt" : 10,      <- optional
+		"blurRemoveCnt": 1,             <- optional
+		"mode" : "default"              <- optional
 	}

```

Modes:
**default**: 3 scanlines per direction - fastest detection so far (because of the nature of movies to have none black content in the center area;)
**classic**: the original implementation - needs less cpu but only covers top left 1/3 of the image and could cause problems with station logos
**osd**: little bit less efficient then default mode but avoids changes caused by receiver OSD overlays like program info or volume bars

![blackborder_scanlines](https://cloud.githubusercontent.com/assets/16512414/12702277/771e8a48-c824-11e5-8a8b-cd2e32f0c342.jpg)
click the image for a better view of the scanlines in osd mode