### PR TITLE
Update LedDeviceAPA102.cpp by pcaffardi

### DIFF
--- a/libsrc/leddevice/LedDeviceAPA102.cpp
+++ b/libsrc/leddevice/LedDeviceAPA102.cpp
@@ -2,7 +2,6 @@
 #include <cstring>
 #include <cstdio>
 #include <iostream>
-#include <algorithm>
 
 // Linux includes
 #include <fcntl.h>
@@ -32,15 +31,15 @@ LedDeviceAPA102::LedDeviceAPA102(const std::string& outputDevice, const unsigned
 int LedDeviceAPA102::write(const std::vector<ColorRgb> &ledValues)
 {
 	const unsigned int startFrameSize = APA102_START_FRAME_BYTES;
-        const unsigned int ledsCount = ledValues.size() ;
-        const unsigned int ledsSize = ledsCount * APA102_LED_BYTES ;
-        const unsigned int endFrameBits = APA102_END_FRAME_BITS(ledsCount) ;
-        const unsigned int endFrameSize = APA102_END_FRAME_BYTES(ledsCount) ;
-        const unsigned int transferSize = startFrameSize + ledsSize + endFrameSize ;
+	const unsigned int ledsCount = ledValues.size() ;
+	const unsigned int ledsSize = ledsCount * APA102_LED_BYTES ;
+	const unsigned int endFrameBits = APA102_END_FRAME_BITS(ledsCount) ;
+	const unsigned int endFrameSize = APA102_END_FRAME_BYTES(ledsCount) ;
+	const unsigned int transferSize = startFrameSize + ledsSize + endFrameSize ;
 
 	if(_ledBuffer.size() != transferSize){
 		_ledBuffer.resize(transferSize, 0x00);
-	} 
+	}
 
 	unsigned idx = 0, i;
 	for (i=0; i<APA102_START_FRAME_BYTES; i++) {
@@ -56,7 +55,7 @@ int LedDeviceAPA102::write(const std::vector<ColorRgb> &ledValues)
 		_ledBuffer[idx++] = rgb.blue;
 	}
 	for(i=0; i<endFrameSize; i++)
-	    _ledBuffer[idx++] = 0x00 ;
+		_ledBuffer[idx++] = 0x00 ;
 
 	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
 }
@@ -64,4 +63,4 @@ int LedDeviceAPA102::write(const std::vector<ColorRgb> &ledValues)
 int LedDeviceAPA102::switchOff()
 {
 	return write(std::vector<ColorRgb>(_ledBuffer.size(), ColorRgb{0,0,0}));
-}   
+}


### PR DESCRIPTION
original commit message by pcaffardi (https://github.com/pcaffardi/hyperion/commit/2d714e6eb075ec57e0973839fe96d2d7a051c57f):

> This fix the previous limit of 64 APA102 leds, because of too short end frame. Now the end frame is computed accordling to this documentation: https://cpldcpu.wordpress.com/2014/11/30/understanding-the-apa102-superled/. Tested on my 98 leds, it works fine.
> 
> I suggest to modify hyperion to allow LED drivers to apply the brightness parameter because APA102 has a parameter for that, without the need to elaborate RGB color to simulate it (result is wrong colors!). Is it possible to introduce such parameter in LED drivers and let the driver apply that?

this fix is mentioned in #480 #364 and #206 
original authors seems inactive and this patch is out there since a long time
so i decided to make a request to finaly get this nice fix into master
all credits to pcaffardi