### PR TITLE
Fix compile issue for missing ceil function

### DIFF
--- a/libsrc/blackborder/BlackBorderDetector.cpp
+++ b/libsrc/blackborder/BlackBorderDetector.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 // BlackBorders includes
 #include <blackborder/BlackBorderDetector.h>
+#include <cmath>
 
 using namespace hyperion;
 

--- a/libsrc/hyperion/ImageProcessorFactory.cpp
+++ b/libsrc/hyperion/ImageProcessorFactory.cpp
@@ -1,7 +1,3 @@
-
-// STL includes
-#include <cmath>
-
 // Hyperion includes
 #include <hyperion/ImageProcessorFactory.h>
 #include <hyperion/ImageProcessor.h>


### PR DESCRIPTION
Missing 'ceil' function on OSX