### PR TITLE
Update CMakeLists.txt for OpenElec -> Python 2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,6 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 # Prefer static linking over dynamic
 #set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
 
-set(CMAKE_BUILD_TYPE "Debug")
-#set(CMAKE_BUILD_TYPE "Release")
-
 # enable C++11
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -std=c++11 -Wall")

--- a/libsrc/effectengine/CMakeLists.txt
+++ b/libsrc/effectengine/CMakeLists.txt
@@ -1,5 +1,7 @@
 
 find_package(PythonLibs REQUIRED)
+#OpenElec uses 2.7, if you want to compile for OpenElec require 2.7
+#find_package(PythonLibs 2.7 REQUIRED)
 
 # Include the python directory. Also include the parent (which is for example /usr/include)
 # which may be required when it is not includes by the (cross-) compiler by default.


### PR DESCRIPTION
If you want to compile for OpenElec on Raspberry Pi, you must use Python 2.7