### PR TITLE
Add new WS281x driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "dependencies/external/protobuf"]
 	path = dependencies/external/protobuf
 	url = https://github.com/tvdzwan/protobuf.git
+[submodule "dependencies/external/rpi_ws281x"]
+	path = dependencies/external/rpi_ws281x
+	url = https://github.com/jgarff/rpi_ws281x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ message(STATUS "ENABLE_V4L2 = " ${ENABLE_V4L2})
 option(ENABLE_WS2812BPWM   "Enable the WS2812b-PWM device" OFF)
 message(STATUS "ENABLE_WS2812BPWM = " ${ENABLE_WS2812BPWM})
 
+option(ENABLE_WS281XPWM   "Enable the WS281x-PWM device" OFF)
+message(STATUS "ENABLE_WS281XPWM = " ${ENABLE_WS281XPWM})
+
 option(ENABLE_X11 "Enable the X11 grabber" OFF)
 message(STATUS "ENABLE_X11 = " ${ENABLE_X11})
 
@@ -55,6 +58,10 @@ endif(ENABLE_FB AND ENABLE_OSX)
 if(ENABLE_OSX AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and osx grabber cannot be used at the same time")
 endif(ENABLE_OSX AND ENABLE_DISPMANX)
+
+if(ENABLE_WS2812BPWM AND ENABLE_WS281XPWM)
+	message(FATAL_ERROR "WS2812b and WS281x drivers cannot be used at the same time")
+endif(ENABLE_WS2812BPWM AND ENABLE_WS281XPWM)
 
 #if(ENABLE_QT5)
 # TODO vs ENABLE_QT4?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,6 @@ if(ENABLE_OSX AND ENABLE_DISPMANX)
 	message(FATAL_ERROR "dispmanx grabber and osx grabber cannot be used at the same time")
 endif(ENABLE_OSX AND ENABLE_DISPMANX)
 
-if(ENABLE_WS2812BPWM AND ENABLE_WS281XPWM)
-	message(FATAL_ERROR "WS2812b and WS281x drivers cannot be used at the same time")
-endif(ENABLE_WS2812BPWM AND ENABLE_WS281XPWM)
-
 #if(ENABLE_QT5)
 # TODO vs ENABLE_QT4?
 #endif(ENABLE_QT5)

--- a/HyperionConfig.h.in
+++ b/HyperionConfig.h.in
@@ -12,6 +12,9 @@
 // Define to enable the ws2812b-pwm-device
 #cmakedefine ENABLE_WS2812BPWM
 
+// Define to enable the ws281x-pwm-via-dma-device using jgarff's library
+#cmakedefine ENABLE_WS281XPWM
+
 // Define to enable the spi-device
 #cmakedefine ENABLE_TINKERFORGE
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -4,6 +4,13 @@ add_subdirectory(build/jsoncpp)
 add_subdirectory(build/serial)
 add_subdirectory(build/tinkerforge)
 
+if(ENABLE_WS281XPWM)
+	add_library(ws281x
+		external/rpi_ws281x/mailbox.c external/rpi_ws281x/ws2811.c
+		external/rpi_ws281x/pwm.c external/rpi_ws281x/dma.c
+		external/rpi_ws281x/rpihw.c)
+endif(ENABLE_WS281XPWM)
+
 if(ENABLE_PROTOBUF)
 	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared protobuf library")
 	add_subdirectory(external/protobuf)

--- a/libsrc/leddevice/CMakeLists.txt
+++ b/libsrc/leddevice/CMakeLists.txt
@@ -97,6 +97,18 @@ SET(Leddevice_SOURCES
 )
 endif(ENABLE_WS2812BPWM)
 
+if(ENABLE_WS281XPWM)
+include_directories(../../dependencies/external/rpi_ws281x)
+SET(Leddevice_HEADERS
+		${Leddevice_HEADERS}
+		${CURRENT_SOURCE_DIR}/LedDeviceWS281x.h
+	)
+SET(Leddevice_SOURCES
+		${Leddevice_SOURCES}
+		${CURRENT_SOURCE_DIR}/LedDeviceWS281x.cpp
+)
+endif(ENABLE_WS281XPWM)
+
 if(ENABLE_TINKERFORGE)
 	SET(Leddevice_HEADERS
 			${Leddevice_HEADERS}
@@ -136,6 +148,10 @@ target_link_libraries(leddevice
 
 if(ENABLE_TINKERFORGE)
 	target_link_libraries(leddevice tinkerforge)
+endif()
+
+if(ENABLE_WS281XPWM)
+	target_link_libraries(leddevice ws281x)
 endif()
 
 if(APPLE)

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -42,6 +42,10 @@
 	#include "LedDeviceWS2812b.h"
 #endif
 
+#ifdef ENABLE_WS281XPWM
+	#include "LedDeviceWS281x.h"
+#endif
+
 LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 {
 	std::cout << "Device configuration: " << deviceConfig << std::endl;
@@ -284,6 +288,18 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 	{
 		LedDeviceWS2812b * ledDeviceWS2812b = new LedDeviceWS2812b();
 		device = ledDeviceWS2812b;
+	}
+#endif
+#ifdef ENABLE_WS281XPWM
+	else if (type == "ws281x")
+	{
+		const int gpio = deviceConfig.get("gpio", 18).asInt();
+		const int leds = deviceConfig.get("leds", 12).asInt();
+		const uint32_t freq = deviceConfig.get("freq", (Json::UInt)800000ul).asInt();
+		const int dmanum = deviceConfig.get("dmanum", 5).asInt();
+
+		LedDeviceWS281x * ledDeviceWS281x = new LedDeviceWS281x(gpio, leds, freq, dmanum);
+		device = ledDeviceWS281x;
 	}
 #endif
 	else

--- a/libsrc/leddevice/LedDeviceWS281x.cpp
+++ b/libsrc/leddevice/LedDeviceWS281x.cpp
@@ -1,0 +1,78 @@
+#include <iostream>
+
+#include "LedDeviceWS281x.h"
+
+// Constructor
+LedDeviceWS281x::LedDeviceWS281x(const int gpio, const int leds, const uint32_t freq, const int dmanum)
+{
+	initialized = false;
+	led_string.freq = freq;
+	led_string.dmanum = dmanum;
+	led_string.channel[0].gpionum = gpio;
+	led_string.channel[0].invert = 0;
+	led_string.channel[0].count = leds;
+	led_string.channel[0].brightness = 255;
+	led_string.channel[0].strip_type = WS2811_STRIP_RGB;
+
+	led_string.channel[1].gpionum = 0;
+	led_string.channel[1].invert = 0;
+	led_string.channel[1].count = 0;
+	led_string.channel[1].brightness = 0;
+	led_string.channel[0].strip_type = WS2811_STRIP_RGB;
+	if (ws2811_init(&led_string) < 0) {
+		std::cout << "Unable to initialize ws281x library." << std::endl;
+		throw -1;
+	}
+	initialized = true;
+}
+
+// Send new values down the LED chain
+int LedDeviceWS281x::write(const std::vector<ColorRgb> &ledValues)
+{
+	if (!initialized)
+		return -1;
+
+	int idx = 0;
+	for (const ColorRgb& color : ledValues)
+	{
+		if (idx >= led_string.channel[0].count)
+			break;
+		led_string.channel[0].leds[idx++] = ((uint32_t)color.red << 16) + ((uint32_t)color.green << 8) + color.blue;
+	}
+	while (idx < led_string.channel[0].count)
+		led_string.channel[0].leds[idx++] = 0;
+
+	if (ws2811_render(&led_string))
+		return -1;
+
+	return 0;
+}
+
+// Turn off the LEDs by sending 000000's
+// TODO Allow optional power switch out another gpio, if this code handles it can
+// make it more likely we don't accidentally drive data into an off strip
+int LedDeviceWS281x::switchOff()
+{
+	if (!initialized)
+		return -1;
+
+	int idx = 0;
+	while (idx < led_string.channel[0].count)
+		led_string.channel[0].leds[idx++] = 0;
+
+	if (ws2811_render(&led_string))
+		return -1;
+
+	return 0;
+}
+
+// Destructor
+LedDeviceWS281x::~LedDeviceWS281x()
+{
+	if (initialized)
+	{
+		std::cout << "Shutdown WS281x PWM and DMA channel" << std::endl;
+		ws2811_fini(&led_string);
+	}
+	initialized = false;
+}

--- a/libsrc/leddevice/LedDeviceWS281x.h
+++ b/libsrc/leddevice/LedDeviceWS281x.h
@@ -1,0 +1,43 @@
+#ifndef LEDDEVICEWS281X_H_
+#define LEDDEVICEWS281X_H_
+
+#pragma once
+
+#include <leddevice/LedDevice.h>
+#include <ws2811.h>
+
+class LedDeviceWS281x : public LedDevice
+{
+public:
+	///
+	/// Constructs the LedDevice for WS281x (one wire 800kHz)
+	///
+	/// @param gpio   The gpio pin to use (BCM chip counting, default is 18)
+	/// @param leds   The number of leds attached to the gpio pin
+	/// @param freq   The target frequency for the data line, default is 800000
+	/// @param dmanum The DMA channel to use, default is 5
+	///
+	LedDeviceWS281x(const int gpio, const int leds, const uint32_t freq, int dmanum);
+
+	///
+	/// Destructor of the LedDevice, waits for DMA to complete and then cleans up
+	///
+	~LedDeviceWS281x();
+
+	///
+	/// Writes the led color values to the led-device
+	///
+	/// @param ledValues The color-value per led
+	/// @return Zero on succes else negative
+	///
+	virtual int write(const std::vector<ColorRgb> &ledValues);
+
+	/// Switch the leds off
+	virtual int switchOff();
+
+private:
+	ws2811_t led_string;
+	bool initialized;
+};
+
+#endif /* LEDDEVICEWS281X_H_ */


### PR DESCRIPTION
I've noticed that @jgarff has been updating his PWM using DMA ws281x library to keep pace with differences between pi versions.  He's also parameterized the library nicely so it'll be easy to accomodate many different models with different DMA configurations. It also has the added bonus of working on my hardware. @Zappatron's fork works for me as well, but has the unfortunate effect of replacing RPi 1 support.

I've added a new LED driver that is a wrapper around jgarff's library so that hyperion gets the benefits of his recent improvements as well as hopefully future ones too.  At the moment this adds support for Pi 2 and Pi Zero over what is already in hyperion.  It will probably also give Pi 3 support, but I won't be able to test until mine arrives.

I added this as an additional driver to the ws2812bpwm driver with its own #define so that people can choose either particularly while this one is new. However, I believe this driver is a complete superset of the existing driver, but in case I'm wrong about that I've left both.

I think it would be possible to compile in both and choose the driver in the configuration file, but currently I emit an error from cmake if both are selected.  I can test with both if that seems like a desired configuration

In order to allow easier integration of future improvements in the ws281x library, I've included it as a submodule.  If that submodule is not init-ed and the WS281XPWM is not defined, the build should continue to work.

If the submodule seems too onerous, I could explore a different way of integrating jgarff's library.  Built binary in the repo or an external install time dependency perhaps.  Let me know your thoughts on the matter as well as any suggestions.