### PR TITLE
Add ws281x driver parameter for PWM channel

### DIFF
--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -327,8 +327,9 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		const int leds = deviceConfig.get("leds", 12).asInt();
 		const uint32_t freq = deviceConfig.get("freq", (Json::UInt)800000ul).asInt();
 		const int dmanum = deviceConfig.get("dmanum", 5).asInt();
+                const int pwmchannel = deviceConfig.get("pwmchannel", 0).asInt();
 
-		LedDeviceWS281x * ledDeviceWS281x = new LedDeviceWS281x(gpio, leds, freq, dmanum);
+		LedDeviceWS281x * ledDeviceWS281x = new LedDeviceWS281x(gpio, leds, freq, dmanum, pwmchannel);
 		device = ledDeviceWS281x;
 	}
 #endif

--- a/libsrc/leddevice/LedDeviceWS281x.h
+++ b/libsrc/leddevice/LedDeviceWS281x.h
@@ -17,7 +17,7 @@ public:
 	/// @param freq   The target frequency for the data line, default is 800000
 	/// @param dmanum The DMA channel to use, default is 5
 	///
-	LedDeviceWS281x(const int gpio, const int leds, const uint32_t freq, int dmanum);
+	LedDeviceWS281x(const int gpio, const int leds, const uint32_t freq, int dmanum, int pwmchannel);
 
 	///
 	/// Destructor of the LedDevice, waits for DMA to complete and then cleans up
@@ -37,6 +37,7 @@ public:
 
 private:
 	ws2811_t led_string;
+	int chan;
 	bool initialized;
 };
 


### PR DESCRIPTION
**1.** Tell us something about your changes.

The RPi 2 and 3 have two PWM channels and 3 PWM pins available to the
gpio header.  BCM18 and BCM12 run on PWM channel 0.  BCM13 runs on PWM
channel 1.  This change allows BCM13 to be used by allowing the PWM
channel to be specified.

**2.** If this changes affect the .conf file. Please provide the changed section

Adds optional "pwmchannel" parameter to the "device" section.  If unspecified, has the default of 0 which was used before this change.  So, all old .conf files should work the same as they did before.

**3.** Reference a issue (optional)
