### PR TITLE
AtmoOrb smoothing additions

### DIFF
--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -54,8 +54,8 @@ int LedDeviceAtmoOrb::write(const std::vector <ColorRgb> &ledValues) {
     for (const ColorRgb &color : ledValues) {
 
         // If color difference is higher than skipSmoothingDiff than we skip Orb smoothing (if enabled) and send it right away
-        if ((skipSmoothingDiff != 0 && useOrbSmoothing) && (abs(color.red - lastRed) > skipSmoothingDiff || abs(color.blue - lastBlue) > skipSmoothingDiff ||
-                abs(color.green - lastGreen) > skipSmoothingDiff))
+        if ((skipSmoothingDiff != 0 && useOrbSmoothing) && (abs(color.red - lastRed) >= skipSmoothingDiff || abs(color.blue - lastBlue) >= skipSmoothingDiff ||
+                abs(color.green - lastGreen) >= skipSmoothingDiff))
         {
             // Skip Orb smoothing when using  (command type 4)
             for (unsigned int i = 0; i < orbIds.size(); i++) {

--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -57,10 +57,10 @@ int LedDeviceAtmoOrb::write(const std::vector <ColorRgb> &ledValues) {
         if ((skipSmoothingDif != 0 && useOrbSmoothing) && (abs(color.red - lastRed) > skipSmoothingDif || abs(color.blue - lastBlue) > skipSmoothingDif ||
                 abs(color.green - lastGreen) > skipSmoothingDif))
         {
-            // Skip Orb smoothing when using  (command type 2)
+            // Skip Orb smoothing when using  (command type 4)
             for (unsigned int i = 0; i < orbIds.size(); i++) {
                 if (orbIds[i] == idx) {
-                    setColor(idx, color, 2);
+                    setColor(idx, color, 4);
                 }
             }
         }

--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -16,8 +16,8 @@ AtmoOrbLight::AtmoOrbLight(unsigned int id) {
 }
 
 LedDeviceAtmoOrb::LedDeviceAtmoOrb(const std::string &output, bool useOrbSmoothing,
-                                   int transitiontime, int skipSmoothingDif, int port, int numLeds, std::vector<unsigned int> orbIds) :
-        multicastGroup(output.c_str()), useOrbSmoothing(useOrbSmoothing), transitiontime(transitiontime), skipSmoothingDif(skipSmoothingDif),
+                                   int transitiontime, int skipSmoothingDiff, int port, int numLeds, std::vector<unsigned int> orbIds) :
+        multicastGroup(output.c_str()), useOrbSmoothing(useOrbSmoothing), transitiontime(transitiontime), skipSmoothingDiff(skipSmoothingDiff),
         multiCastGroupPort(port), numLeds(numLeds), orbIds(orbIds) {
     manager = new QNetworkAccessManager();
     groupAddress = QHostAddress(multicastGroup);
@@ -53,9 +53,9 @@ int LedDeviceAtmoOrb::write(const std::vector <ColorRgb> &ledValues) {
     unsigned int idx = 1;
     for (const ColorRgb &color : ledValues) {
 
-        // If color difference is higher than skipSmoothingDif than we skip Orb smoothing (if enabled) and send it right away
-        if ((skipSmoothingDif != 0 && useOrbSmoothing) && (abs(color.red - lastRed) > skipSmoothingDif || abs(color.blue - lastBlue) > skipSmoothingDif ||
-                abs(color.green - lastGreen) > skipSmoothingDif))
+        // If color difference is higher than skipSmoothingDiff than we skip Orb smoothing (if enabled) and send it right away
+        if ((skipSmoothingDiff != 0 && useOrbSmoothing) && (abs(color.red - lastRed) > skipSmoothingDiff || abs(color.blue - lastBlue) > skipSmoothingDiff ||
+                abs(color.green - lastGreen) > skipSmoothingDiff))
         {
             // Skip Orb smoothing when using  (command type 4)
             for (unsigned int i = 0; i < orbIds.size(); i++) {

--- a/libsrc/leddevice/LedDeviceAtmoOrb.cpp
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.cpp
@@ -15,9 +15,9 @@ AtmoOrbLight::AtmoOrbLight(unsigned int id) {
     // Not implemented
 }
 
-LedDeviceAtmoOrb::LedDeviceAtmoOrb(const std::string &output, bool switchOffOnBlack,
-                                   int transitiontime, int port, int numLeds, std::vector<unsigned int> orbIds) :
-        multicastGroup(output.c_str()), switchOffOnBlack(switchOffOnBlack), transitiontime(transitiontime),
+LedDeviceAtmoOrb::LedDeviceAtmoOrb(const std::string &output, bool useOrbSmoothing,
+                                   int transitiontime, int skipSmoothingDif, int port, int numLeds, std::vector<unsigned int> orbIds) :
+        multicastGroup(output.c_str()), useOrbSmoothing(useOrbSmoothing), transitiontime(transitiontime), skipSmoothingDif(skipSmoothingDif),
         multiCastGroupPort(port), numLeds(numLeds), orbIds(orbIds) {
     manager = new QNetworkAccessManager();
     groupAddress = QHostAddress(multicastGroup);
@@ -35,30 +35,40 @@ int LedDeviceAtmoOrb::write(const std::vector <ColorRgb> &ledValues) {
         return 0;
     }
 
+    // Command options:
+    //
+    // 1 = force off
+    // 2 = use lamp smoothing and validate by Orb ID
+    // 4 = validate by Orb ID
+
+    // When setting useOrbSmoothing = true it's recommended to disable Hyperion's own smoothing as it will conflict (double smoothing)
+    int commandType = 4;
+    if(useOrbSmoothing)
+    {
+        commandType = 2;
+    }
+
     // Iterate through colors and set Orb color
     // Start off with idx 1 as 0 is reserved for controlling all orbs at once
     unsigned int idx = 1;
     for (const ColorRgb &color : ledValues) {
-        // Options parameter:
-        //
-        // 1 = force off
-        // 2 = use lamp smoothing and validate by Orb ID
-        // 4 = validate by Orb ID
-        //
 
-        if (switchOffOnBlack && color.red == 0 && color.green == 0 && color.blue == 0) {
-            // Force to black
+        // If color difference is higher than skipSmoothingDif than we skip Orb smoothing (if enabled) and send it right away
+        if ((skipSmoothingDif != 0 && useOrbSmoothing) && (abs(color.red - lastRed) > skipSmoothingDif || abs(color.blue - lastBlue) > skipSmoothingDif ||
+                abs(color.green - lastGreen) > skipSmoothingDif))
+        {
+            // Skip Orb smoothing when using  (command type 2)
             for (unsigned int i = 0; i < orbIds.size(); i++) {
                 if (orbIds[i] == idx) {
-                    setColor(idx, color, 1);
+                    setColor(idx, color, 2);
                 }
             }
         }
         else {
-            // Default send color
+            // Send color
             for (unsigned int i = 0; i < orbIds.size(); i++) {
                 if (orbIds[i] == idx) {
-                    setColor(idx, color, 4);
+                    setColor(idx, color, commandType);
                 }
             }
         }
@@ -80,7 +90,7 @@ void LedDeviceAtmoOrb::setColor(unsigned int orbId, const ColorRgb &color, int c
     bytes[2] = 0xEE;
 
     // Command type
-    bytes[3] = 2;
+    bytes[3] = commandType;
 
     // Orb ID
     bytes[4] = orbId;

--- a/libsrc/leddevice/LedDeviceAtmoOrb.h
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.h
@@ -48,7 +48,7 @@ public:
     ///
     /// @param output is the multicast address of Orbs
     ///
-    /// @param switchOffOnBlack turn off Orbs on black (default: false)
+    /// @param useOrbSmoothing use Orbs own (external) smoothing algorithm (default: false)
     ///
     /// @param transitiontime is optional and not used at the moment
     ///
@@ -58,11 +58,9 @@ public:
     ///
     /// @param array containing orb ids
     ///
-    LedDeviceAtmoOrb(const std::string &output, bool switchOffOnBlack =
-    false, int transitiontime = 0, int port = 49692, int numLeds = 24,
-                     std::vector<unsigned int> orbIds = std::vector < unsigned int
-
-    >());
+    LedDeviceAtmoOrb(const std::string &output, bool useOrbSmoothing =
+    false, int transitiontime = 0, int skipSmoothingDif = 0, int port = 49692, int numLeds = 24,
+                     std::vector<unsigned int> orbIds = std::vector < unsigned int>());
 
     ///
     /// Destructor of this device
@@ -87,11 +85,14 @@ private:
     /// String containing multicast group IP address
     QString multicastGroup;
 
-    /// Switch off when detecting black
-    bool switchOffOnBlack;
+    /// use Orbs own (external) smoothing algorithm
+    bool useOrbSmoothing;
 
     /// Transition time between colors (not implemented)
     int transitiontime;
+
+    // Maximum allowed color difference, will skip Orb (external) smoothing once reached
+    int skipSmoothingDif;
 
     /// Multicast port to send data to
     int multiCastGroupPort;

--- a/libsrc/leddevice/LedDeviceAtmoOrb.h
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.h
@@ -48,9 +48,11 @@ public:
     ///
     /// @param output is the multicast address of Orbs
     ///
+    /// @param transitiontime is optional and not used at the moment
+    ///
     /// @param useOrbSmoothing use Orbs own (external) smoothing algorithm (default: false)
     ///
-    /// @param transitiontime is optional and not used at the moment
+    /// @param skipSmoothingDif  minimal color (0-255) difference to override smoothing so that if current and previously received colors are higher than set dif we override smoothing
     ///
     /// @param port is the multicast port.
     ///

--- a/libsrc/leddevice/LedDeviceAtmoOrb.h
+++ b/libsrc/leddevice/LedDeviceAtmoOrb.h
@@ -52,7 +52,7 @@ public:
     ///
     /// @param useOrbSmoothing use Orbs own (external) smoothing algorithm (default: false)
     ///
-    /// @param skipSmoothingDif  minimal color (0-255) difference to override smoothing so that if current and previously received colors are higher than set dif we override smoothing
+    /// @param skipSmoothingDiff  minimal color (0-255) difference to override smoothing so that if current and previously received colors are higher than set dif we override smoothing
     ///
     /// @param port is the multicast port.
     ///
@@ -61,7 +61,7 @@ public:
     /// @param array containing orb ids
     ///
     LedDeviceAtmoOrb(const std::string &output, bool useOrbSmoothing =
-    false, int transitiontime = 0, int skipSmoothingDif = 0, int port = 49692, int numLeds = 24,
+    false, int transitiontime = 0, int skipSmoothingDiff = 0, int port = 49692, int numLeds = 24,
                      std::vector<unsigned int> orbIds = std::vector < unsigned int>());
 
     ///
@@ -94,7 +94,7 @@ private:
     int transitiontime;
 
     // Maximum allowed color difference, will skip Orb (external) smoothing once reached
-    int skipSmoothingDif;
+    int skipSmoothingDiff;
 
     /// Multicast port to send data to
     int multiCastGroupPort;

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -246,35 +246,36 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		}
 		device = new LedDevicePhilipsHue(output, username, switchOffOnBlack, transitiontime, lightIds);
 	}
-  else if (type == "atmoorb")
-  {
+	else if (type == "atmoorb")
+	{
 		const std::string output = deviceConfig["output"].asString();
-		const bool switchOffOnBlack = deviceConfig.get("switchOffOnBlack", true).asBool();
+		const bool useOrbSmoothing = deviceConfig.get("useOrbSmoothing", false).asBool();
 		const int transitiontime = deviceConfig.get("transitiontime", 1).asInt();
+		const int skipSmoothingDif = deviceConfig.get("skipSmoothingDif", 0).asInt();
 		const int port = deviceConfig.get("port", 1).asInt();
 		const int numLeds = deviceConfig.get("numLeds", 1).asInt();
-	  	const std::string orbId = deviceConfig["orbIds"].asString();
+		const std::string orbId = deviceConfig["orbIds"].asString();
 		std::vector<unsigned int> orbIds;
 
 		// If we find multiple Orb ids separate them and add to list
 		const std::string separator (",");
 		if (orbId.find(separator) != std::string::npos) {
-			std::stringstream ss(orbId);
-			std::vector<int> output;
-			unsigned int i;
-			while (ss >> i) {
-				orbIds.push_back(i);
-					if (ss.peek() == ',' || ss.peek() == ' ')
-					ss.ignore();
-			}
+		  std::stringstream ss(orbId);
+		  std::vector<int> output;
+		  unsigned int i;
+		  while (ss >> i) {
+			  orbIds.push_back(i);
+			  if (ss.peek() == ',' || ss.peek() == ' ')
+				  ss.ignore();
+		  }
 		}
 		else
 		{
-			orbIds.push_back(atoi(orbId.c_str()));
+		  orbIds.push_back(atoi(orbId.c_str()));
 		}
 
-		device = new LedDeviceAtmoOrb(output, switchOffOnBlack, transitiontime, port, numLeds, orbIds);
-  }
+		device = new LedDeviceAtmoOrb(output, useOrbSmoothing, transitiontime, skipSmoothingDif, port, numLeds, orbIds);
+	}
 	else if (type == "file")
 	{
 		const std::string output = deviceConfig.get("output", "/dev/null").asString();

--- a/libsrc/leddevice/LedDeviceFactory.cpp
+++ b/libsrc/leddevice/LedDeviceFactory.cpp
@@ -251,7 +251,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		const std::string output = deviceConfig["output"].asString();
 		const bool useOrbSmoothing = deviceConfig.get("useOrbSmoothing", false).asBool();
 		const int transitiontime = deviceConfig.get("transitiontime", 1).asInt();
-		const int skipSmoothingDif = deviceConfig.get("skipSmoothingDif", 0).asInt();
+		const int skipSmoothingDiff = deviceConfig.get("skipSmoothingDiff", 0).asInt();
 		const int port = deviceConfig.get("port", 1).asInt();
 		const int numLeds = deviceConfig.get("numLeds", 1).asInt();
 		const std::string orbId = deviceConfig["orbIds"].asString();
@@ -274,7 +274,7 @@ LedDevice * LedDeviceFactory::construct(const Json::Value & deviceConfig)
 		  orbIds.push_back(atoi(orbId.c_str()));
 		}
 
-		device = new LedDeviceAtmoOrb(output, useOrbSmoothing, transitiontime, skipSmoothingDif, port, numLeds, orbIds);
+		device = new LedDeviceAtmoOrb(output, useOrbSmoothing, transitiontime, skipSmoothingDiff, port, numLeds, orbIds);
 	}
 	else if (type == "file")
 	{


### PR DESCRIPTION
**1.** Tell us something about your changes.

Added new AtmoOrb options:

- Choose between Orbs internal smoothing or that of Hyperion  and defined by **useOrbSmoothing** bool setting (true = external Orb smoothing)
- minimal color (0-255) difference to override smoothing so that if current and previously received colors are higher than diff we override Orbs external smoothing and is defined by **skipSmoothingDiff** integer setting

skipSmoothingDiff setting allows for faster transitions when the minimal color difference is defined (0-255), for instance if you go from full white to black it can clear smoothing right away for instant color change, this is only used when Orbs smoothing is enabled (useOrbSmoothing = true);

**2.** If this changes affect the .conf file. Please provide the changed section

Removed bool setting: **switchOffOnBlack**
Added new bool setting: **useOrbSmoothing**
Added new integer setting: **skipSmoothingDiff** (0-255 range)

Sample config and updated wiki:

https://gist.github.com/RickDB/dfbb39c16a556ffe591b
https://github.com/tvdzwan/hyperion/wiki/AtmoOrb-device